### PR TITLE
Path fix for adb

### DIFF
--- a/src/main/scala/AndroidProject.scala
+++ b/src/main/scala/AndroidProject.scala
@@ -75,9 +75,10 @@ abstract class AndroidProject(info: ProjectInfo) extends DefaultProject(info) {
     case "android-2.2" => 8
   }
   
+  def androidPlatformToolsPath = androidSdkPath / "platform-tools"
   def androidToolsPath = androidSdkPath / "tools"
   def apkbuilderPath = androidToolsPath / apkbuilderName
-  def adbPath = androidToolsPath / adbName
+  def adbPath = androidPlatformToolsPath / adbName
   def androidPlatformPath = androidSdkPath / "platforms" / androidPlatformName
   def platformToolsPath = androidPlatformPath / "tools"
   def aaptPath = platformToolsPath / aaptName


### PR DESCRIPTION
I'm not sure if the path for adb has never been correct (I doubt it), however in the version of the Android SDK that I have locally adb is in platform-tools instead of tools. My update changes this, however it may be the case that a more extensive fix is necessary if it's possible that adb might live in either location depending on when you downloaded the SDK/which version of the SDK you have installed (I have SDK tools revision 8 and platform tools revision 1 installed).
