### PR TITLE
ScalaTest version 1.0 does not work with Scala 2.8.1

### DIFF
--- a/script/create_project
+++ b/script/create_project
@@ -96,7 +96,7 @@ val projectDef = """
   |
   |  class MainProject(info: ProjectInfo) extends AndroidProject(info) with Defaults with MarketPublish {
   |    val keyalias  = "change-me"
-  |    val scalatest = "org.scalatest" % "scalatest" % "1.0" % "test"
+  |    val scalatest = "org.scalatest" % "scalatest" % "#{scalatestVersion}" % "test"
   |  }
   |
   |  class TestProject(info: ProjectInfo) extends AndroidTestProject(info) with Defaults
@@ -196,6 +196,7 @@ class Generator(val config:Config) {
     case "activity" => config.activity.capitalize
     case "platform" => config.platform
     case "scalaVersion" => config.scalaVersion
+    case "scalatestVersion" => if(config.scalaVersion == "2.7.7") "1.0" else "1.2"
     case _ => fail("unknown substitution: " + v)
   })
 

--- a/script/create_project
+++ b/script/create_project
@@ -196,7 +196,7 @@ class Generator(val config:Config) {
     case "activity" => config.activity.capitalize
     case "platform" => config.platform
     case "scalaVersion" => config.scalaVersion
-    case "scalatestVersion" => if(config.scalaVersion == "2.7.7") "1.0" else "1.2"
+    case "scalatestVersion" => if(config.scalaVersion == "2.7.7") "1.1" else "1.2"
     case _ => fail("unknown substitution: " + v)
   })
 


### PR DESCRIPTION
(Note, I submitted an issue for this as well)

Currently the 'test' target fails to compile because the version of ScalaTest used is not compatible with the default version of Scala.

These commits change the version of ScalaTest that projects created with the create_project script depend on according to their Scala version.

Scala 2.7.7 => ScalaTest 1.1
All Others => ScalaTest 1.2
