### PR TITLE
I've added a mixin for generating AndroidManifest version attributes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,7 +55,7 @@ on [cross-building][cb].
 If you would like your AndroidManifest.xml file to automatically inherit
 versionName and versionCode from your SBT project, add the 
 `AndroidManifestGenerator` trait to your project.  It will look for an
-AndroidManifestIn.xml file, and add versionName and versionCode to that
+AndroidManifest.xml file, and add versionName and versionCode to that
 template.
 
 When you want to increase your version number, just use the standard SBT

--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ To install and start the main activity in the [Android Emulator][emu]
 
 To build a signed package for release into the Marketplace:
 
-    > sign-release
+    > prepare-market
 
 ##Scala Versions
 
@@ -50,6 +50,17 @@ on [cross-building][cb].
 
 [cb]: http://code.google.com/p/simple-build-tool/wiki/CrossBuild
 
+##Android manifest files
+
+If you would like your AndroidManifest.xml file to automatically inherit
+versionName and versionCode from your SBT project, add the 
+`AndroidManifestGenerator` trait to your project.  It will look for an
+AndroidManifestIn.xml file, and add versionName and versionCode to that
+template.
+
+When you want to increase your version number, just use the standard SBT
+`increment-version` command.  
+ 
 ##Typed resources references
 
 As an enhancement to the Android build process, this plugin can

--- a/script/create_project
+++ b/script/create_project
@@ -40,9 +40,7 @@ case class Config(
   val sdkVersion:String, val `package`:String, val scalaVersion:String, val activity:String)
 
 val config = Config(project, project, platform, apiLevel, pkg, scalaVersion, activity)
-val manifestXml = <manifest xmlns:android="http://schemas.android.com/apk/res/android" package={config.`package`}
-          android:versionCode="1"
-          android:versionName="0.1">
+val manifestXml = <manifest xmlns:android="http://schemas.android.com/apk/res/android" package={config.`package`}>
     <uses-sdk android:minSdkVersion={config.sdkVersion}/>
     <application android:label="@string/app_name" android:icon="@drawable/app_icon">
         <activity android:name={"."+config.activity} android:label="@string/app_name">
@@ -94,7 +92,7 @@ val projectDef = """
   |  lazy val main  = project(".", "#{project}", new MainProject(_))
   |  lazy val tests = project("tests",  "tests", new TestProject(_), main)
   |
-  |  class MainProject(info: ProjectInfo) extends AndroidProject(info) with Defaults with MarketPublish {
+  |  class MainProject(info: ProjectInfo) extends AndroidProject(info) with Defaults with MarketPublish with AndroidManifestGenerator {
   |    val keyalias  = "change-me"
   |    val scalatest = "org.scalatest" % "scalatest" % "#{scalatestVersion}" % "test"
   |  }
@@ -148,7 +146,7 @@ class Generator(val config:Config) {
   import scala.xml.Node
 
   val Resources = List("drawable", "layout", "values", "xml")
-  val Manifest = new File(config.target, "src/main/AndroidManifest.xml")
+  val Manifest = new File(config.target, "src/main/AndroidManifestIn.xml")
   val TestManifest = new File(config.target, "tests/src/main/AndroidManifest.xml")
   val Strings = new File(config.target, "src/main/res/values/strings.xml")
   val Project = new File(config.target, "project/build/" + config.project.capitalize + ".scala")

--- a/src/main/scala/AndroidManifestGenerator.scala
+++ b/src/main/scala/AndroidManifestGenerator.scala
@@ -51,7 +51,7 @@ trait AndroidManifestGenerator extends AndroidProject {
     if (manifest.attribute(namespacePrefix, "versionName").isDefined) 
       error("android:versionName should not be defined in template")
     val applications = manifest \ "application"
-    val wasDebuggable = applications.exists(_.attribute(namespacePrefix + "debuggable").isDefined)
+    val wasDebuggable = applications.exists(_.attribute(namespacePrefix, "debuggable").isDefined)
 
     val verName = new PrefixedAttribute("android", "versionName", version.toString, Null)
     val verCode = new PrefixedAttribute("android", "versionCode", versionCode.value.toString, Null)

--- a/src/main/scala/AndroidManifestGenerator.scala
+++ b/src/main/scala/AndroidManifestGenerator.scala
@@ -35,9 +35,18 @@ trait AndroidManifestGenerator extends AndroidProject {
   }
 
   /// Force regeneration of the manfest
-  def discardAndroidManifest() {
+  private def discardAndroidManifest() {
     FileUtilities.clean(androidManifestPath, log)
   }
+ 
+  def cleanAndroidManifestAction = task {
+    discardAndroidManifest()
+    None
+  } describedAs("Deletes the generated Android manifest.")
+  
+  lazy val cleanAndroidManifest = cleanAndroidManifestAction
+
+  override def cleanAction = super.cleanAction dependsOn(cleanAndroidManifest)
 
   /// a customized manifest file is needed for the following actions  
   override def aaptGenerateAction = super.aaptGenerateAction dependsOn(generateAndroidManifest)

--- a/src/main/scala/AndroidManifestGenerator.scala
+++ b/src/main/scala/AndroidManifestGenerator.scala
@@ -1,0 +1,65 @@
+
+
+import sbt._
+import Process._
+import scala.xml._
+
+object AndroidManifestGenerator {
+  val DefaultAndroidManifestTemplateName = "AndroidManifestIn.xml"
+}
+
+/** Generates AndroidManifest.xml from AndroidManifestIn.xml, by applying various sbt properties.
+
+This plug-in currently generates the manifest versionCode and versionName attributes.  It would be
+possible to also generate correct settings for debug for market vs. debug builds but that is TODO.
+*/
+trait AndroidManifestGenerator extends AndroidProject {
+  import AndroidManifestGenerator._
+
+  /// The android version code - stored as a property, starts at 1 and increments whenever the user
+  /// calls incrementVersion
+  lazy val versionCode = propertyOptional[Int](1)
+
+  def androidManifestTemplateName = DefaultAndroidManifestTemplateName 
+  def androidManifestTemplatePath = mainSourcePath / androidManifestTemplateName
+
+  override def incrementVersionNumber() {
+    super.incrementVersionNumber()
+
+    versionCode() = versionCode.value + 1
+    log.info("Android version code incremented to " + versionCode.value + ".  Manifest will be regenerated.")
+
+    discardAndroidManifest()
+  }
+
+  /// Force regeneration of the manfest
+  def discardAndroidManifest() {
+    FileUtilities.clean(androidManifestPath, log)
+  }
+  
+  override def aaptGenerateTask = super.aaptGenerateTask dependsOn(generateAndroidManifest)
+
+  def generateAndroidManifestAction = fileTask(androidManifestPath from androidManifestTemplatePath) {
+
+    val namespacePrefix = "http://schemas.android.com/apk/res/android"
+    val manifest = XML.loadFile(androidManifestTemplatePath.asFile)
+    if (manifest.attribute(namespacePrefix,"versionCode").isDefined) 
+      error("android:versionCode should not be defined in template")
+    if (manifest.attribute(namespacePrefix, "versionName").isDefined) 
+      error("android:versionName should not be defined in template")
+    val applications = manifest \ "application"
+    val wasDebuggable = applications.exists(_.attribute(namespacePrefix + "debuggable").isDefined)
+
+    val verName = new PrefixedAttribute("android", "versionName", version.toString, Null)
+    val verCode = new PrefixedAttribute("android", "versionCode", versionCode.value.toString, Null)
+
+    val newManifest = manifest % verName % verCode
+
+    // Write the modified manifest
+    XML.save(androidManifestPath.absolutePath, newManifest)
+
+    None
+  } describedAs("Generates a customized AndroidManifest.xml with current build number and debug settings.")
+
+  lazy val generateAndroidManifest = generateAndroidManifestAction
+}

--- a/src/main/scala/AndroidManifestGenerator.scala
+++ b/src/main/scala/AndroidManifestGenerator.scala
@@ -5,7 +5,7 @@ import Process._
 import scala.xml._
 
 object AndroidManifestGenerator {
-  val DefaultAndroidManifestTemplateName = "AndroidManifestIn.xml"
+  val DefaultAndroidManifestTemplateName = "AndroidManifest.xml"
 }
 
 /** Generates AndroidManifest.xml from AndroidManifestIn.xml, by applying various sbt properties.
@@ -23,6 +23,8 @@ trait AndroidManifestGenerator extends AndroidProject {
   def androidManifestTemplateName = DefaultAndroidManifestTemplateName 
   def androidManifestTemplatePath = mainSourcePath / androidManifestTemplateName
 
+  override def androidManifestPath = "src_managed" / "main" / androidManifestName
+
   override def incrementVersionNumber() {
     super.incrementVersionNumber()
 
@@ -36,8 +38,9 @@ trait AndroidManifestGenerator extends AndroidProject {
   def discardAndroidManifest() {
     FileUtilities.clean(androidManifestPath, log)
   }
-  
-  override def aaptGenerateTask = super.aaptGenerateTask dependsOn(generateAndroidManifest)
+
+  /// a customized manifest file is needed for the following actions  
+  override def aaptGenerateAction = super.aaptGenerateAction dependsOn(generateAndroidManifest)
 
   def generateAndroidManifestAction = fileTask(androidManifestPath from androidManifestTemplatePath) {
 

--- a/src/main/scala/AndroidProject.scala
+++ b/src/main/scala/AndroidProject.scala
@@ -233,7 +233,7 @@ abstract class AndroidProject(info: ProjectInfo) extends DefaultProject(info) {
   def uninstallTask(emulator: Boolean) = adbTask(emulator, { Unit => "uninstall "+manifestPackage })
   
   def adbTask(emulator: Boolean, action: Unit => String) = execTask {<x>
-      {adbPath.absolutePath} {if (emulator) "-e" else "-d"} {action}
+      {adbPath.absolutePath} {if (emulator) "-e" else "-d"} {action()}
    </x>}
          
   lazy val manifest:scala.xml.Elem = scala.xml.XML.loadFile(androidManifestPath.asFile)

--- a/src/main/scala/AndroidProject.scala
+++ b/src/main/scala/AndroidProject.scala
@@ -227,12 +227,12 @@ abstract class AndroidProject(info: ProjectInfo) extends DefaultProject(info) {
   lazy val uninstallDevice = uninstallDeviceAction
   def uninstallDeviceAction = uninstallTask(false) describedAs("Uninstall package on the default device.")
 
-  def installTask(emulator: Boolean) = adbTask(emulator, "install "+packageApkPath.absolutePath)
-  def reinstallTask(emulator: Boolean) = adbTask(emulator, "install -r "+packageApkPath.absolutePath)
-  def startTask(emulator: Boolean) = adbTask(emulator, "shell am start -a android.intent.action.MAIN -n "+manifestPackage+"/"+launcherActivity)
-  def uninstallTask(emulator: Boolean) = adbTask(emulator, "uninstall "+manifestPackage)
+  def installTask(emulator: Boolean) = adbTask(emulator, { Unit => "install "+packageApkPath.absolutePath } )
+  def reinstallTask(emulator: Boolean) = adbTask(emulator, { Unit => "install -r "+packageApkPath.absolutePath })
+  def startTask(emulator: Boolean) = adbTask(emulator, { Unit => "shell am start -a android.intent.action.MAIN -n "+manifestPackage+"/"+launcherActivity })
+  def uninstallTask(emulator: Boolean) = adbTask(emulator, { Unit => "uninstall "+manifestPackage })
   
-  def adbTask(emulator: Boolean, action: String) = execTask {<x>
+  def adbTask(emulator: Boolean, action: Unit => String) = execTask {<x>
       {adbPath.absolutePath} {if (emulator) "-e" else "-d"} {action}
    </x>}
          

--- a/src/main/scala/AndroidTestProject.scala
+++ b/src/main/scala/AndroidTestProject.scala
@@ -6,5 +6,5 @@ abstract class AndroidTestProject(info: ProjectInfo) extends AndroidProject(info
   lazy val testEmulator = instrumentationTestAction(true) describedAs("runs tests in emulator") dependsOn reinstallEmulator
   lazy val testDevice = instrumentationTestAction(false) describedAs("runs tests on device") dependsOn reinstallDevice
 
-  def instrumentationTestAction(emulator:Boolean) = adbTask(emulator, "shell am instrument -w "+manifestPackage+"/android.test.InstrumentationTestRunner") describedAs("runs instrumentation tests")        
+  def instrumentationTestAction(emulator:Boolean) = adbTask(emulator, { Unit => "shell am instrument -w "+manifestPackage+"/android.test.InstrumentationTestRunner" }) describedAs("runs instrumentation tests")        
 }


### PR DESCRIPTION
Hi,

I've been using your excellent sbt plugin but I got tired of having to remember to bump up versions for my market releases.  My solution to this was to make a mixin that automatically populates the versionCode and versionName attributes in AndroidManifest.xml.  To use this, add the AndroidManifestgenerator mixin to your project - it will read 
from src/main/AndroidManifest.xml and generate src_managed/main/AndroidManifest.xml.  

The versions used come from the sbt version property.  To bump up the version use 'increment-version'.

What do you think of this idea?  Can you review this diff somewhat carefully?  I've never had cause to futz with sbt innards before so I might be doing something dumb.

Kevin
