### PR TITLE
Stop start-emulator and start-device from trying to start the tests app

### DIFF
--- a/src/main/scala/AndroidTestProject.scala
+++ b/src/main/scala/AndroidTestProject.scala
@@ -3,6 +3,10 @@ import sbt._
 abstract class AndroidTestProject(info: ProjectInfo) extends AndroidProject(info) {
   override def proguardInJars = Path.emptyPathFinder
 
+  // Normally it makes no sense to start a test application, so make these actions no-ops.
+  override def startEmulatorAction = task { None }
+  override def startDeviceAction = task { None }
+
   lazy val testEmulator = instrumentationTestAction(true) describedAs("runs tests in emulator") dependsOn reinstallEmulator
   lazy val testDevice = instrumentationTestAction(false) describedAs("runs tests on device") dependsOn reinstallDevice
 


### PR DESCRIPTION
At the moment start-emulator and start-device, as well as starting the main application, also starts the tests app. And the default test app (because it has no Activity) crashes as soon as it's started.

This change overrides start-emulator and start-device so that they're no-ops for an AndroidTestProject.
