### PR TITLE
Put a stopper in the ProGuard warnings firehose

### DIFF
--- a/src/main/scala/AndroidProject.scala
+++ b/src/main/scala/AndroidProject.scala
@@ -139,6 +139,8 @@ abstract class AndroidProject(info: ProjectInfo) extends DefaultProject(info) {
                "-outjars" :: classesMinJarPath.absolutePath ::
                "-libraryjars" :: libraryJarPath.getPaths.mkString(File.pathSeparator) :: 
                "-dontwarn" :: "-dontoptimize" :: "-dontobfuscate" ::
+               "-dontnote scala.Enumeration" ::
+               "-dontnote org.xml.sax.EntityResolver" ::
                "-keep public class * extends android.app.Activity" ::
                "-keep public class * extends android.app.Service" ::
                "-keep public class * extends android.appwidget.AppWidgetProvider" ::


### PR DESCRIPTION
Kill the ProGuard warnings. This was unashamedly stolen from:

https://lampsvn.epfl.ch/trac/scala/browser/android-examples/trunk/android-sdk/configs/proguard/default-debug.cfg
