### PR TITLE
Fix https://github.com/jberkel/android-plugin/issues/45

### DIFF
--- a/src/main/scala/ApkBuilder.scala
+++ b/src/main/scala/ApkBuilder.scala
@@ -25,6 +25,7 @@ class ApkBuilder(project: Installable, debug: Boolean) {
     project.packageApkPath.asFile, project.resourcesApkPath.asFile, project.classesDexPath.asFile, keyStore, new PrintStream(outputStream))
   setDebugMode(debug)
   addNativeLibraries(project.nativeLibrariesPath.asFile, null)
+  addResourcesFromJar(project.classesMinJarPath.asFile)
 
   def build() = try {
     sealApk
@@ -51,6 +52,15 @@ class ApkBuilder(project: Installable, debug: Boolean) {
       method.invoke(builder, nativeFolder, abiFilter)
     }
   } 
+
+  /// Copy most non class files from the given standard java jar file
+  ///
+  /// (used to let classloader.getResource work for legacy java libs
+  /// on android)
+  def addResourcesFromJar(jarFile: File) {
+    def method = klass.getMethod("addResourcesFromJar", classOf[File]) 
+    method.invoke(builder, jarFile)
+  }  
 
   def sealApk() {
     val method = klass.getMethod("sealApk")


### PR DESCRIPTION
For my project I'm using some 'standard' java JARs (apache sshd). Those jars include various property files which are eventually read using getResource() or getResourceAsStream(). Android properly looks in the apk for these files, but apkBuilder by default does not propagate them. Historically ant would pass in --rp to apkBuilder so these resources would get included.

I think sbt should invoke apkBuilder.addResourcesFromJar and pass in the post proguard jar. This would allow sbt to behave similarly to java android projects, where users pass in "-keeppackagenames org.apache.sshd" to proguard, and then the downstream Android tools do the right thing.

I've made this fix and will submit a pull request shortly...
