### PR TITLE
Add option to create TR.scala in an appropriate subdirectory.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,6 +84,9 @@ is issued by the plugin when the same ID is used for different types
 of a resources; the type of resources retrieved by that ID will be
 unpredictable.
 
+It is possible to generate the `TR.scala` file in a directory that matches its
+package.  To do this, simply override `trInPackageDirectory` and make it true.
+
 ##Building Java Android projects with sbt
 
 If you don't use Scala yet and want to use the plugin to build your existing

--- a/src/main/scala/TypedResources.scala
+++ b/src/main/scala/TypedResources.scala
@@ -2,9 +2,15 @@ import sbt._
 import scala.xml._
 
 trait TypedResources extends BaseAndroidProject {
+  def trInPackageDirectory = false
   def managedScalaPath = "src_managed" / "main" / "scala"
   /** Typed resource file to be generated, also includes interfaces to access these resources. */
-  def typedResource = managedScalaPath / "TR.scala"
+  def typedResourcePath =
+    if(trInPackageDirectory)
+      Path.fromString(managedScalaPath, manifestPackage.replace('.', java.io.File.separatorChar))
+    else
+      managedScalaPath
+  def typedResource = typedResourcePath / "TR.scala"
   abstract override def mainSourceRoots = super.mainSourceRoots +++ managedScalaPath
   def layoutResources = mainResPath / "layout" ** "*.xml"
   override def compileAction = super.compileAction dependsOn generateTypedResources


### PR DESCRIPTION
Some tools, IDEA in particular, like it best when a source file appears in a directory that matches the package of the file's code.  Currently, the plug-in produces `TR.scala` in `src_managed/main/scala`, which is generally fine.  This request adds the option `trInPackageDirectory` that when true, places the `TR.scala` in an appropriate subdirectory.  Otherwise, the default behaviour is retained.
