### PR TITLE
Add basic NDK support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -111,6 +111,18 @@ or
 The screenshots will be written to `emulator.png` / `device.png` in the project
 root directory.
 
+## Using the NDK to build C/C++ libraries
+
+If you use the NDK in your project, you can add the `NdkSupport` trait to your
+project definition.  This will cause the `compile` command to call the
+`ndk-build` tool and the `clean` command to remove the `src/main/obj` and
+`src/main/libs` directories.  The plug-in expects your `Android.mk` and your
+C/C++ sources to be in the `src/main/jni` directory.
+
+In order for the NDK support to work, you should set the environment variable
+`ANDROID_NDK_HOME` to the root of the NDK (the directory that contains the
+`ndk-build` executable).
+
 ##Hacking on the plugin
 
 If you need make modifications to the plugin itself, you can compile

--- a/src/main/scala/NdkSupport.scala
+++ b/src/main/scala/NdkSupport.scala
@@ -1,0 +1,74 @@
+import java.io.File
+import sbt._
+import Process._
+
+/** Provides some default values for the NdkSupport trait. */
+object NdkSupport {
+  /** The default name for the 'ndk-build' tool. */
+  val DefaultNdkBuildName = "ndk-build"
+  /** The default directory name for native sources. */
+  val DefaultJniDirectoryName = "jni"
+  /** The default directory name for compiled native objects. */
+  val DefaultObjDirectoryName = "obj"
+  /** The default directory name for compiled native libraries. */
+  val DefaultLibsDirectoryName = "libs"
+  /** The list of environment variables to check for the NDK. */
+  val DefaultEnvs = List("ANDROID_NDK_HOME", "ANDROID_NDK_ROOT")
+}
+
+
+/** Trait that mixes in compilation of C/C++ sources using the NDK.
+  *
+  * @author Daniel Solano Gómez */
+trait NdkSupport extends BaseAndroidProject {
+  import NdkSupport._
+
+  // ndk-related names
+  def ndkBuildName = DefaultNdkBuildName
+  def jniDirectoryName = DefaultJniDirectoryName
+  def objDirectoryName = DefaultObjDirectoryName
+  def libsDirectoryName = DefaultLibsDirectoryName
+
+  // ndk-related paths
+  def mainJniSourcePath = mainSourcePath / jniDirectoryName
+  def mainNativeOutputPath =
+    Path.fromFile(mainJniSourcePath.asFile.getParentFile)
+  def mainNativeObjectPath = mainNativeOutputPath / objDirectoryName
+  def mainNativeLibraryPath = mainNativeOutputPath / libsDirectoryName
+  def ndkBuildPath = androidNdkPath / ndkBuildName
+
+  lazy val androidNdkPath =
+    determineAndroidNdkPath.getOrElse(error("Android NDK not found.  "+
+      "You might need to set "+DefaultEnvs.mkString(" or ")))
+
+  /** Finds the NDK path by using some environment variables to see if they
+    * point to a directory that contains the 'ndk-build' executable. */
+  def determineAndroidNdkPath:Option[Path] = {
+    val paths = for {
+      e <- DefaultEnvs
+      p = System.getenv(e)
+      if p != null
+      if new File(p, ndkBuildName).canExecute
+    } yield p
+    if (paths.isEmpty) None else Some(Path.fromFile(paths.first))
+  }
+
+  /** Make compile depend on ndkBuild. */
+  override def compileAction = super.compileAction dependsOn ndkBuild
+  /** Make clean action clean up 'obj' and 'libs' directories. */
+  override def cleanAction =
+    super.cleanAction dependsOn(cleanTask(mainNativeObjectPath),
+                                cleanTask(mainNativeLibraryPath))
+
+  // The new ndk-build action
+  lazy val ndkBuild = ndkBuildAction
+  def ndkBuildAction =
+    ndkBuildTask describedAs("Compile native C/C++ sources.")
+  /** Calls 'ndk-build' to compile native sources, changing to the parent
+    * directory of the main JNI source path. */
+  def ndkBuildTask = execTask {
+      <x>
+        {ndkBuildPath.absolutePath} -C {mainNativeOutputPath.absolutePath}
+      </x>
+    } dependsOn(directory(mainJniSourcePath))
+}


### PR DESCRIPTION
This starts adding some basic NDK support to the android-plugin.  For now, it doesn't do anything else than call `ndk-build` during compilation and clean up the `obj` and `libs` directories during cleanup.  Like the plugin, this depends on an environment variable being set up: either ANDROID_NDK_HOME or ANDROID_NDK_ROOT.

It seems to be in a good enough state for basic use.  I am using it in a project right now, but I welcome any feedback.  I suppose it would be good to add gdb support.

One thing I don't like is the pollution of the `src/main` directory with the output directories `obj` and `libs`.  Unfortunately, I don't see an easy way of modifying that.  On the other hand, with the `libs` directory where it is, the ApkBuilder picks it up automatically.
