### PR TITLE
Simplify TypedResources usage a bit.

### DIFF
--- a/src/main/scala/TypedResources.scala
+++ b/src/main/scala/TypedResources.scala
@@ -57,18 +57,19 @@ object TypedResources {
             |%s
             |}
             |trait TypedViewHolder {
-            |  def view: View
-            |  def findView[T](tr: TypedResource[T]) = view.findViewById(tr.id).asInstanceOf[T]
+            |  def findViewById( id: Int ): View
+            |  def findView[T](tr: TypedResource[T]) = findViewById(tr.id).asInstanceOf[T]
             |}
-            |trait TypedView extends View with TypedViewHolder { def view = this }
-            |trait TypedActivityHolder {
-            |  def activity: Activity
-            |  def findView[T](tr: TypedResource[T]) = activity.findViewById(tr.id).asInstanceOf[T]
-            |}
-            |trait TypedActivity extends Activity with TypedActivityHolder { def activity = this }
+            |trait TypedView extends View with TypedViewHolder
+            |trait TypedActivityHolder extends TypedViewHolder
+            |trait TypedActivity extends Activity with TypedActivityHolder
             |object TypedResource {
-            |  implicit def view2typed(v: View) = new TypedViewHolder { def view = v }
-            |  implicit def activity2typed(act: Activity) = new TypedActivityHolder { def activity = act }
+            |  implicit def view2typed(v: View) = new TypedViewHolder { 
+            |    def findViewById( id: Int ) = v.findViewById( id )
+            |  }
+            |  implicit def activity2typed(a: Activity) = new TypedViewHolder { 
+            |    def findViewById( id: Int ) = a.findViewById( id )
+            |  }
             |}
             |""".stripMargin.format(
               manifestPackage, resources map { case (id, classname) =>


### PR DESCRIPTION
This patch redefines the 'TypedViewHolder' trait so that it can be
applied to anything with a findViewById method, using structural
typing --- without requiring anything other than the 'findViewById'
method itself to exist.  The 'def view = this' and 'def activity = this'
of the TypedViewHolder and TypedActivityHolder traits are no longer
required; it's now possible to say

  class MyActivity extends Activity with TypedViewHolder {
    ...
  }

without further ceremony.

For back-compatibility, TypedActivityHolder is still defined as a
synonym for TypedViewHolder (though TypedViewHolder serves for both,
and may be better named --- a TypedActivityHolder holds Views, not
Activities).

The implicit conversions in the TypedResource object are likewise
still defined, and still work.
