### PR TITLE
Restore "android library project" support to 0.11 branch

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -65,7 +65,7 @@ object AndroidBase {
       val status = processes.reduceLeft{ _ #&& _ } !
 
       if (status > 0) {
-        error( "aapt failed; consult output for possible reasons." )
+        sys.error( "aapt failed; consult output for possible reasons." )
       }
 
       for (( path, pkg ) <- aaptAllTargets;

--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -6,20 +6,72 @@ import AndroidHelpers._
 
 object AndroidBase {
 
-  private def aaptGenerateTask =
-    (manifestPackage, aaptPath, manifestPath, mainResPath, jarPath, managedJavaPath) map {
-    (mPackage, aPath, mPath, resPath, jPath, javaPath) =>
-    Process (<x>
-      {aPath.absolutePath} package --auto-add-overlay -m
-        --custom-package {mPackage}
-        -M {mPath.absolutePath}
-        -S {resPath.absolutePath}
-        -I {jPath.absolutePath}
-        -J {javaPath.absolutePath}
-    </x>) !
+  private def resDirsWithDepsTask = 
+    (thisProject, mainResPath, Keys.settings) map {
+      ( thisProj, thisProjResPath, settings ) => {
 
-    javaPath ** "R.java" get
-  }
+        // Find dependent projects with resources of their own, and
+        // collect the resource directories.
+
+        def androidSetting[T]( aKey:SettingKey[T], projectRef: ProjectRef )=
+          ((aKey in Android) in (projectRef)) get settings
+
+        val depResPaths: Seq[java.io.File] = 
+          for (dep        <- thisProj.dependencies;
+               depResPath <- androidSetting( mainResPath, dep.project ))
+          yield depResPath
+      
+        depResPaths :+ thisProjResPath
+    }}
+
+  private def aaptGenerateTask =
+    (manifestPackage, aaptPath, manifestPath, resDirsWithDeps, jarPath, managedJavaPath,
+     thisProject, Keys.settings) map {
+    (mPackage, aPath, mPath, resPaths, jPath, javaPath, thisProj, settings) => {
+
+      // Find dependent projects that have settings that look like
+      // they need an R.java.  Presumably, they only need their own
+      // resources, but we give them the whole set, because that's
+      // the only way to make the IDs consistent
+
+      def androidSetting[T]( androidKey:SettingKey[T], projectRef: ProjectRef )=
+        ((androidKey in Android) in (projectRef)) get settings
+
+      val aaptDepTargets = (
+        for (dep             <- thisProj.dependencies;
+             managedJavaPath <- androidSetting( managedJavaPath, dep.project );
+             projPackage     <- androidSetting( manifestPackage, dep.project ))
+          yield ( managedJavaPath, projPackage ))
+            
+      val aaptAllTargets = aaptDepTargets :+ (javaPath, mPackage)
+
+      for (( path, pkg ) <- aaptAllTargets) { 
+        IO.createDirectory( path ) 
+      }
+
+      val resPathArgs = resPaths.map{"-S "+_.absolutePath+" "}.reduceLeft( _+_ )
+
+      val processes =
+        for (( projManagedJavaPath, projPackage ) <- aaptAllTargets)
+        yield Process (<x>
+                       {aPath.absolutePath} package --auto-add-overlay -m
+                       --custom-package {projPackage}
+                       -M {mPath.absolutePath}
+                       {resPathArgs}
+                       -I {jPath.absolutePath}
+                       -J {projManagedJavaPath.absolutePath}
+                       </x>)
+
+      val status = processes.reduceLeft{ _ #&& _ } !
+
+      if (status > 0) {
+        error( "aapt failed; consult output for possible reasons." )
+      }
+
+      for (( path, pkg ) <- aaptAllTargets;
+           file <- ( path ** "R.java" ) get )
+        yield file
+    }}
 
   private def aidlGenerateTask =
     (sourceDirectories, idlPath, managedJavaPath, javaSource, streams) map {
@@ -111,9 +163,9 @@ object AndroidBase {
     },
 
     makeManagedJavaPath <<= directory(managedJavaPath),
+    resDirsWithDeps <<= resDirsWithDepsTask,
 
     aaptGenerate <<= aaptGenerateTask,
-    aaptGenerate <<= aaptGenerate dependsOn makeManagedJavaPath,
     aidlGenerate <<= aidlGenerateTask,
 
     unmanagedJars in Compile <++= (libraryJarPath) map (_.map(Attributed.blank(_))),

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -31,7 +31,7 @@ object AndroidInstall {
                            </x>).!
 
       if (status > 0) {
-        error( "aapt failed; consult output for possible reasons." )
+        sys.error( "aapt failed; consult output for possible reasons." )
       }
 
       resApkPath

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -18,17 +18,24 @@ object AndroidInstall {
   }
 
   private def aaptPackageTask: Project.Initialize[Task[File]] =
-  (aaptPath, manifestPath, mainResPath, mainAssetsPath, jarPath, resourcesApkPath) map {
-    (apPath, manPath, rPath, assetPath, jPath, resApkPath) => Process(<x>
-      {apPath} package --auto-add-overlay -f
-        -M {manPath}
-        -S {rPath}
-        -A {assetPath}
-        -I {jPath}
-        -F {resApkPath}
-    </x>).!
-    resApkPath
-  }
+  (aaptPath, manifestPath, resDirsWithDeps, mainAssetsPath, jarPath, resourcesApkPath) map {
+    (apPath, manPath, rPaths, assetPath, jPath, resApkPath) => {
+      val resPathArgs = rPaths.map{"-S "+_.absolutePath+" "}.reduceLeft( _+_ )
+      val status = Process(<x>
+                           {apPath} package --auto-add-overlay -f
+                           -M {manPath}
+                           {resPathArgs}
+                           -A {assetPath}
+                           -I {jPath}
+                           -F {resApkPath}
+                           </x>).!
+
+      if (status > 0) {
+        error( "aapt failed; consult output for possible reasons." )
+      }
+
+      resApkPath
+  }}
 
   private def dxTask: Project.Initialize[Task[File]] =
     (scalaInstance, dxJavaOpts, dxPath, classDirectory,

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -93,6 +93,7 @@ object AndroidKeys {
   val manifestTemplatePath = SettingKey[File]("manifest-template-path")
 
   /** Base Tasks */
+  val resDirsWithDeps = TaskKey[Seq[File]]("resource-dirs-with-deps")
   val aaptGenerate = TaskKey[Seq[File]]("aapt-generate", "Generate R.java")
   val aidlGenerate = TaskKey[Seq[File]]("aidl-generate",
     "Generate Java classes from .aidl files.")


### PR DESCRIPTION
This is lingering cleanup in the transition from sbt 0.7 to newer versions,
done against the 0.11 branch of the plugin.

It restores the "Android Library Project" functionality:  if an Android
project has other Android projects in its direct classPath dependencies,
and you build an APK for that project, it will include resources for the
base project and its dependencies, and the IDs will be made consistent.
(In fact, by generating the same R.java file for all of them, with the
appropriate package name for each; it's a kludge, but that's how the
stock library project support is working now, too.)

This differs slightly from the previous version, in that it will include
only Android projects declared as direct dependencies, and not all the
Android projects in the build.  There may be only one sbt-android build
on the planet complex enough that it makes sense to be this selective,
but it happens to be mine ;-).

(It might make sense to include resources for dependencies-of-dependencies,
but I'm not sure anyone has a practical use for that...)

There are two commits here.  The first works in the 0.10 and 0.11 versions
of the plugin, and gets deprecation warnings in 0.11.  The second eliminates
the deprecation warnings in 0.11, and breaks things completely in 0.10.  So,
if you want to update the current master (the 0.10 branch), cherry-pick the
first commit only.
