### PR TITLE
Do not generate a non-compilable typed resources file

### DIFF
--- a/src/main/scala/TypedResources.scala
+++ b/src/main/scala/TypedResources.scala
@@ -20,6 +20,8 @@ object TypedResources {
         }
       }
 
+      val reserved = List("extends", "trait", "type", "val", "var", "with")
+
       val resources = layoutResources.get.flatMap { path =>
         XML.loadFile(path).descendant_or_self flatMap { node =>
           // all nodes
@@ -45,6 +47,8 @@ object TypedResources {
             if (v0 != v) s.log.warn("Resource id '%s' mapped to %s and %s" format (k, v0, v))
           }
           m + (k -> v)
+      }.filterNot {
+        case (id, _) => reserved.contains(id)
       }
 
       IO.write(typedResource,


### PR DESCRIPTION
Filter out Scala keywords that are not already Java keywords.
