### PR TITLE
Quoted proguard jar paths

### DIFF
--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -66,10 +66,11 @@ object AndroidInstall {
           val manifestr = List("!META-INF/MANIFEST.MF", "R.class", "R$*.class",
                                "TR.class", "TR$.class", "library.properties")
           val sep = JFile.pathSeparator
+          val inJars = ("\"" + classDirectory.absolutePath + "\"") +:
+                       proguardInJars.map("\""+_+"\""+manifestr.mkString("(", ",!**/", ")"))
+
           val args = (
-                "-injars" :: classDirectory.absolutePath + sep +
-                 (if (!proguardInJars.isEmpty)
-                 proguardInJars.map(_+manifestr.mkString("(", ",!**/", ")")).mkString(sep) else "") ::
+                 "-injars" :: inJars.mkString(sep) ::
                  "-outjars" :: classesMinJarPath.absolutePath ::
                  "-libraryjars" :: libraryJarPath.mkString(sep) ::
                  Nil) ++

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -71,8 +71,8 @@ object AndroidInstall {
 
           val args = (
                  "-injars" :: inJars.mkString(sep) ::
-                 "-outjars" :: classesMinJarPath.absolutePath ::
-                 "-libraryjars" :: libraryJarPath.mkString(sep) ::
+                 "-outjars" :: "\""+classesMinJarPath.absolutePath+"\"" ::
+                 "-libraryjars" :: libraryJarPath.map("\""+_+"\"").mkString(sep) ::
                  Nil) ++
                  optimizationOptions ++ (
                  "-dontwarn" :: "-dontobfuscate" ::


### PR DESCRIPTION
ProGuard will blow up if it is given a non-quoted classpath with a space in it.  This branch wraps all the paths passed to ProGuard with quotes.
