### PR TITLE
Don't exclude un-managed libraries from ProGuard

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -102,10 +102,9 @@ object AndroidBase {
 
     proguardOption := "",
     proguardExclude <<=
-      (libraryJarPath, classDirectory, resourceDirectory, unmanagedClasspath in Compile) map {
-        (libPath, classDirectory, resourceDirectory, unmanagedClasspath) =>
-          val temp = libPath +++ classDirectory +++ resourceDirectory
-          unmanagedClasspath.foldLeft(temp)(_ +++ _.data) get
+      (libraryJarPath, classDirectory, resourceDirectory) map {
+        (libPath, classDirectory, resourceDirectory) =>
+          (libPath +++ classDirectory +++ resourceDirectory) get
       },
     proguardInJars <<= (fullClasspath, proguardExclude) map {
       (runClasspath, proguardExclude) =>


### PR DESCRIPTION
Excluding unmanaged jars from ProGuard means they don't get packaged in the jar, dex'ed and ultimately apk'ed.  This commit removes them from the proguardExclude task.
