### PR TITLE
Call process with seq

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -9,14 +9,12 @@ object AndroidBase {
   private def aaptGenerateTask =
     (manifestPackage, aaptPath, manifestPath, mainResPath, jarPath, managedJavaPath) map {
     (mPackage, aPath, mPath, resPath, jPath, javaPath) =>
-    Process (<x>
-      {aPath.absolutePath} package --auto-add-overlay -m
-        --custom-package {mPackage}
-        -M {mPath.absolutePath}
-        -S {resPath.absolutePath}
-        -I {jPath.absolutePath}
-        -J {javaPath.absolutePath}
-    </x>) !
+    Seq(aPath.absolutePath, "package", "--auto-add-overlay", "-m",
+        "--custom-package", mPackage,
+        "-M", mPath.absolutePath,
+        "-S", resPath.absolutePath,
+        "-I", jPath.absolutePath,
+        "-J", javaPath.absolutePath) !
 
     javaPath ** "R.java" get
   }

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -45,9 +45,12 @@ object AndroidInstall {
 
       if (!uptodate) {
         val noLocals = if (proguardOptimizations.isEmpty) "" else "--no-locals"
-        val dxCmd = String.format("%s %s --dex " + noLocals + " --output=%s %s",
-          dxPath, dxMemoryParameter(dxJavaOpts), classesDexPath, inputs.mkString(" "))
-        streams.log.debug(dxCmd)
+        val dxCmd = Seq(dxPath.absolutePath,
+                        dxMemoryParameter(dxJavaOpts),
+                        "--dex", noLocals,
+                        "--output="+classesDexPath.absolutePath,
+                        inputs.mkString(" ")).filter(_.length > 0)
+        streams.log.debug(dxCmd.mkString(" "))
         streams.log.info("Dexing "+classesDexPath)
         streams.log.debug(dxCmd !!)
       } else streams.log.debug("dex file uptodate, skipping")

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -19,14 +19,15 @@ object AndroidInstall {
 
   private def aaptPackageTask: Project.Initialize[Task[File]] =
   (aaptPath, manifestPath, mainResPath, mainAssetsPath, jarPath, resourcesApkPath) map {
-    (apPath, manPath, rPath, assetPath, jPath, resApkPath) => Process(<x>
-      {apPath} package --auto-add-overlay -f
-        -M {manPath}
-        -S {rPath}
-        -A {assetPath}
-        -I {jPath}
-        -F {resApkPath}
-    </x>).!
+    (apPath, manPath, rPath, assetPath, jPath, resApkPath) =>
+
+    Seq(apPath.absolutePath, "package", "--auto-add-overlay", "-f",
+        "-M", manPath.absolutePath,
+        "-S", rPath.absolutePath,
+        "-A", assetPath.absolutePath,
+        "-I", jPath.absolutePath,
+        "-F", resApkPath.absolutePath) !
+
     resApkPath
   }
 


### PR DESCRIPTION
Using formatted strings to execute processes results in arguments with spaces in them not being escaped.  Using a Seq() instead will allow Process to escape the spaces correctly and in a platform independent way.  This should be the last thing needed to support spaces in paths on Windows.
