### PR TITLE
Support for library projects.

### DIFF
--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -81,6 +81,7 @@ object AndroidKeys {
 
   /** Market Publish Settings */
   val keystorePath = SettingKey[File]("key-store-path")
+  val keystorePasswordPath = SettingKey[Option[File]]("key-store-password-path")
   val zipAlignPath = SettingKey[File]("zip-align-path", "Path to zipalign")
   val packageAlignedName = SettingKey[String]("package-aligned-name")
   val packageAlignedPath = SettingKey[File]("package-aligned-path")


### PR DESCRIPTION
Using the --non-constant-id option to aapt we make sure that the
library projects' ids are not inlined by the compiler.
Unfortunately we need to several R.java files, each identical but with
different packages, since the library projects will be looking for them there.

Thanks to rst--this code is based on his but uses a different method.

You need to set isLibraryProject in Android := true for all of the library projects. Only direct dependencies are included, but it is now safe to flatten your dependency tree because all of the compilation occurs in the parent project.
