### PR TITLE
Fix for recent Android SDK

### DIFF
--- a/src/main/scala/ApkBuilder.scala
+++ b/src/main/scala/ApkBuilder.scala
@@ -37,7 +37,7 @@ class ApkBuilder(project: ApkConfig, debug: Boolean) {
   setDebugMode(debug)
 
   def build() = try {
-    addNativeLibraries(project.nativeLibrariesPath)
+    addNativeLibraries(project.nativeLibrariesPath, null)
     addResourcesFromJar(project.classesMinJarPath)
     addSourceFolder(project.resourceDirectory)
     sealApk
@@ -56,10 +56,17 @@ class ApkBuilder(project: ApkConfig, debug: Boolean) {
     method.invoke(builder, debug.asInstanceOf[Object])
   }
 
-  def addNativeLibraries(nativeFolder: File) {
+  def addNativeLibraries(nativeFolder: File, abiFilter: String) {
     if (nativeFolder.exists && nativeFolder.isDirectory) {
-      val method = klass.getMethod("addNativeLibraries", classOf[File])
-      method.invoke(builder, nativeFolder)
+      try {
+        val method = klass.getMethod("addNativeLibraries", classOf[File], classOf[String])
+        method.invoke(builder, nativeFolder, abiFilter)
+      } catch {
+        case e: java.lang.NoSuchMethodException => {
+          val method = klass.getMethod("addNativeLibraries", classOf[File])
+          method.invoke(builder, nativeFolder)
+        }
+      }
     }
   }
 

--- a/src/main/scala/ApkBuilder.scala
+++ b/src/main/scala/ApkBuilder.scala
@@ -37,7 +37,7 @@ class ApkBuilder(project: ApkConfig, debug: Boolean) {
   setDebugMode(debug)
 
   def build() = try {
-    addNativeLibraries(project.nativeLibrariesPath, null)
+    addNativeLibraries(project.nativeLibrariesPath)
     addResourcesFromJar(project.classesMinJarPath)
     addSourceFolder(project.resourceDirectory)
     sealApk
@@ -56,10 +56,10 @@ class ApkBuilder(project: ApkConfig, debug: Boolean) {
     method.invoke(builder, debug.asInstanceOf[Object])
   }
 
-  def addNativeLibraries(nativeFolder: File, abiFilter: String) {
+  def addNativeLibraries(nativeFolder: File) {
     if (nativeFolder.exists && nativeFolder.isDirectory) {
-      val method = klass.getMethod("addNativeLibraries", classOf[File], classOf[String])
-      method.invoke(builder, nativeFolder, abiFilter)
+      val method = klass.getMethod("addNativeLibraries", classOf[File])
+      method.invoke(builder, nativeFolder)
     }
   }
 


### PR DESCRIPTION
With latest SDK, when building apk, for example `android:package-debug` task, this task fails with error log `java.lang.NullPointerException`. Internally this is caused by

```
java.lang.NoSuchMethodException: com.android.sdklib.build.ApkBuilder.addNativeLibraries(java.io.File, java.lang.String)
        at java.lang.Class.getMethod(Class.java:1605)
        at ApkBuilder.addNativeLibraries(ApkBuilder.scala:61)
```

This seems to be because Android SDK's `ApkBuilder#addNativeLibraries` method has changed: it is `void addNativeLibraries(File nativeFolder)` now. This pull-req is to follow this change.
