### PR TITLE
add ability to predex external libraries

### DIFF
--- a/src/main/scala/AndroidDefault.scala
+++ b/src/main/scala/AndroidDefault.scala
@@ -15,7 +15,7 @@ object AndroidDefaults {
   val DefaultClassesMinJarName = "classes.min.jar"
   val DefaultClassesDexName = "classes.dex"
   val DefaultResourcesApkName = "resources.apk"
-  val DefaultDxOpts = ("-JXmx512m", true)
+  val DefaultDxOpts = ("-JXmx512m", None)
   val DefaultManifestSchema = "http://schemas.android.com/apk/res/android"
   val DefaultEnvs = List("ANDROID_SDK_HOME", "ANDROID_SDK_ROOT", "ANDROID_HOME")
 

--- a/src/main/scala/AndroidDefault.scala
+++ b/src/main/scala/AndroidDefault.scala
@@ -15,7 +15,7 @@ object AndroidDefaults {
   val DefaultClassesMinJarName = "classes.min.jar"
   val DefaultClassesDexName = "classes.dex"
   val DefaultResourcesApkName = "resources.apk"
-  val DefaultDxJavaOpts = "-JXmx512m"
+  val DefaultDxOpts = ("-JXmx512m", true)
   val DefaultManifestSchema = "http://schemas.android.com/apk/res/android"
   val DefaultEnvs = List("ANDROID_SDK_HOME", "ANDROID_SDK_ROOT", "ANDROID_HOME")
 
@@ -31,7 +31,7 @@ object AndroidDefaults {
     classesMinJarName := DefaultClassesMinJarName,
     classesDexName := DefaultClassesDexName,
     resourcesApkName := DefaultResourcesApkName,
-    dxJavaOpts := DefaultDxJavaOpts,
+    dxOpts := DefaultDxOpts,
     manifestSchema := DefaultManifestSchema, 
     envs := DefaultEnvs 
   )

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -37,8 +37,14 @@ object AndroidInstall {
     (scalaInstance, dxOpts, dxPath, classDirectory,
      proguardInJars, proguard, proguardOptimizations, classesDexPath, streams) =>
       def dexing(inputs: Seq[JFile], output: JFile) {
-        val uptodate = output.exists &&
-          !inputs.exists(_.lastModified > output.lastModified)
+        val uptodate = output.exists && inputs.forall(input =>
+          input.isDirectory match {
+            case true =>
+              (input ** "*").get.forall(_.lastModified <= output.lastModified)
+            case false =>
+              input.lastModified <= output.lastModified
+          }
+        )
 
         if (!uptodate) {
           val noLocals = if (proguardOptimizations.isEmpty) "" else "--no-locals"

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -31,7 +31,7 @@ object AndroidKeys {
   val classesMinJarName = SettingKey[String]("classes-min-jar-name")
   val classesDexName = SettingKey[String]("classes-dex-name")
   val resourcesApkName = SettingKey[String]("resources-apk-name")
-  val dxJavaOpts = SettingKey[String]("dx-java-opts")
+  val dxOpts = SettingKey[Tuple2[String, Boolean]]("dx-opts")
   val manifestSchema = SettingKey[String]("manifest-schema")
   val envs = SettingKey[Seq[String]]("envs")
 

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -31,7 +31,7 @@ object AndroidKeys {
   val classesMinJarName = SettingKey[String]("classes-min-jar-name")
   val classesDexName = SettingKey[String]("classes-dex-name")
   val resourcesApkName = SettingKey[String]("resources-apk-name")
-  val dxOpts = SettingKey[Tuple2[String, Boolean]]("dx-opts")
+  val dxOpts = SettingKey[Tuple2[String, Option[Seq[String]]]]("dx-opts")
   val manifestSchema = SettingKey[String]("manifest-schema")
   val envs = SettingKey[Seq[String]]("envs")
 


### PR DESCRIPTION
Add ability to predex project dependencies with dxOpt (modified dxJavaOpt)
This is allow preload external jars (like scala runtime) to android device.
We're able to significantly reduce time to build apk at development stage.

Predex jar generated at classesDexPath / predex, also simple permission descriptor generated for /system/etc/permissions. Proguard must be switched off, of course.

After that we preload libraries at emulator or device and add something like that :-)

&lt;uses-library android:name="slf4j-android-1.6.1-RC1" android:required="true"/>

to AndroidManifest.xml

Work flawlessly with Eclipse 3.7.1, ScalaIDE 2, scala 2.9.1, sbt 0.11.2
