### PR TITLE
use all available processors for running `dx`

### DIFF
--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -43,6 +43,7 @@ object AndroidInstall {
         val dxCmd = (Seq(dxPath.absolutePath,
                         dxMemoryParameter(dxJavaOpts),
                         "--dex", noLocals,
+                        "--num-threads="+java.lang.Runtime.getRuntime.availableProcessors,
                         "--output="+classesDexPath.absolutePath) ++
                         dxInputs.get.map(_.absolutePath)).filter(_.length > 0)
         streams.log.debug(dxCmd.mkString(" "))


### PR DESCRIPTION
Just a smallish improvement to set `dx --num-threads=` to the numbers of available processors
