### PR TITLE
support apklib dependencies

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -28,9 +28,7 @@ object AndroidBase {
     (update in Compile, sourceManaged, managedJavaPath, resourceManaged, streams) map {
     (updateReport, srcManaged, javaManaged, resManaged, s) => {
 
-      val deps = updateReport.allFiles
-
-      val apklibs = deps filter { _.ext.matches("""(?i)apklib""") }
+      val apklibs = updateReport.matching(artifactFilter(`type` = "apklib"))
 
       apklibs map  { apklib =>
         s.log.info("extracting apklib " + apklib.name)

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -93,7 +93,7 @@ object AndroidKeys {
   val manifestTemplatePath = SettingKey[File]("manifest-template-path")
 
   /** Base Tasks */
-  case class LibraryProject(pkgName: String, manifest: File, srcDir: Option[File], resDir: Option[File], assetsDir: Option[File])
+  case class LibraryProject(pkgName: String, manifest: File, sources: Set[File], resDir: Option[File], assetsDir: Option[File])
 
   val extractApkLibDependencies = TaskKey[Seq[LibraryProject]]("apklib-dependencies", "Unpack apklib dependencies")
 

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -67,6 +67,7 @@ object AndroidKeys {
   val resourcesApkPath = SettingKey[File]("resources-apk-path")
   val packageApkPath = SettingKey[File]("package-apk-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
+  val projectLibraryDependencies = SettingKey[Seq[ModuleID]]("project-library-dependencies", "Declares managed apklib dependencies.")
 
   /** Install Settings */
   val packageConfig = TaskKey[ApkConfig]("package-config",
@@ -92,6 +93,11 @@ object AndroidKeys {
   val manifestTemplatePath = SettingKey[File]("manifest-template-path")
 
   /** Base Tasks */
+  case class LibraryProject(pkgName: String, manifest: File, srcDir: Option[File], resDir: Option[File], assetsDir: Option[File])
+
+  val extractApkLibDependencies = TaskKey[Seq[LibraryProject]]("apklib-dependencies", "Unpack apklib dependencies")
+
+  val apklibSources = TaskKey[Seq[File]]("apklib-sources", "Enumerate Java sources from apklibs")
   val aaptGenerate = TaskKey[Seq[File]]("aapt-generate", "Generate R.java")
   val aidlGenerate = TaskKey[Seq[File]]("aidl-generate",
     "Generate Java classes from .aidl files.")


### PR DESCRIPTION
Adds a key for specifying apklib dependencies, which may be fetched via ivy.  Extracts the apklibs, adds sources, runs aapt.

based on prior work by Matthew Willis at github.com/appamatto
