### PR TITLE
Run javah to generate JNI C header files.

### DIFF
--- a/src/main/scala/AndroidNdkKeys.scala
+++ b/src/main/scala/AndroidNdkKeys.scala
@@ -27,6 +27,8 @@ object AndroidNdkKeys {
 
   val javahOutputDirectory = SettingKey[File]("javah-output-directory",
       "The directory where JNI headers are written to.")
+  val javahOutputFile = SettingKey[Option[File]]("javah-output-file",
+      "filename for the generated C header, relative to javah-output-directory")
   val javahOutputEnv = SettingKey[String]("javah-output-env",
       "Name of the make environment variable to bind to the javah-output-directory")
 

--- a/src/main/scala/AndroidNdkKeys.scala
+++ b/src/main/scala/AndroidNdkKeys.scala
@@ -20,4 +20,16 @@ object AndroidNdkKeys {
   val ndkBuild = TaskKey[Unit]("ndk-build", "Compile native C/C++ sources.")
   val ndkClean = TaskKey[Unit]("ndk-clean", "Clean resources built from native C/C++ sources.")
 
+  val javahName = SettingKey[String]("javah-name", "The name of the javah command for generating JNI headers")
+  val javahPath = SettingKey[String]("javah-path", "The path to the javah executable")
+  val javah = TaskKey[Unit]("javah", "Produce C headers from Java classes with native methods")
+  val javahClean = TaskKey[Unit]("javah-clean", "Clean C headers built from Java classes with native methods")
+
+  val javahOutputDirectory = SettingKey[File]("javah-output-directory",
+      "The directory where JNI headers are written to.")
+  val javahOutputEnv = SettingKey[String]("javah-output-env",
+      "Name of the make environment variable to bind to the javah-output-directory")
+
+  val jniClasses = SettingKey[Seq[String]]("jni-classes",
+      "Fully qualified names of classes with native methods for which JNI headers are to be generated.")
 }


### PR DESCRIPTION
When using JNI one typically uses javah to generate a C header containing the constants and function declarations for classes that contain native methods.

This patch lets SBT run javah to generate the header file for a given set of classes.

Setting `jniClasses in Android`  specifies the classes with native methods for which C headers should be generated.

By default, javah will generate a separate C header file for each JNI class. To generate a single C header file instead, set `javahOutputFile in Android`.

The make environment variable `SBT_MANAGED_JNI_INCLUDE` can be used to refer to the directory containing the generated header files.

``` make
# Android.mk
LOCAL_C_INCLUDES += \
        ... \
        $(SBT_MANAGED_JNI_INCLUDE)
```

For more details see the settings defined in `AndroidNdkKeys`.
