### PR TITLE
Minimize test work

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -11,9 +11,9 @@ import sbinary.DefaultProtocol.StringFormat
 object AndroidBase {
 
   private def apklibSourcesTask =
-    (extractApkLibDependencies, streams) map {
-    (projectLibs, s) => {
-      if (!projectLibs.isEmpty) {
+    (extractApkLibDependencies, streams, skipApkLibDependencies) map {
+    (projectLibs, s, skip) => {
+      if (!skip && !projectLibs.isEmpty) {
         s.log.debug("generating source files from apklibs")
         val xs = for (
           l <- projectLibs;
@@ -27,10 +27,14 @@ object AndroidBase {
   }
 
   private def apklibDependenciesTask =
-    (update in Compile, sourceManaged, managedJavaPath, resourceManaged, streams) map {
-    (updateReport, srcManaged, javaManaged, resManaged, s) => {
+    (update in Compile, sourceManaged, managedJavaPath, resourceManaged, streams, skipApkLibDependencies) map {
+    (updateReport, srcManaged, javaManaged, resManaged, s, skip) => {
 
-      val apklibs = updateReport.matching(artifactFilter(`type` = "apklib"))
+      val apklibs: Seq[File] = if (skip) {
+        Seq.empty
+      } else {
+        updateReport.matching(artifactFilter(`type` = "apklib"))
+      }
 
       apklibs map  { apklib =>
         s.log.info("extracting apklib " + apklib.name)
@@ -194,7 +198,8 @@ object AndroidBase {
 
     resourceDirectories <+= (mainAssetsPath),
 
-    cachePasswords := false
+    cachePasswords := false,
+    skipApkLibDependencies := false
   ) ++ Seq (
     // Handle the delegates for android settings
     classDirectory <<= (classDirectory in Compile),

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -96,6 +96,7 @@ object AndroidKeys {
   case class LibraryProject(pkgName: String, manifest: File, sources: Set[File], resDir: Option[File], assetsDir: Option[File])
 
   val extractApkLibDependencies = TaskKey[Seq[LibraryProject]]("apklib-dependencies", "Unpack apklib dependencies")
+  val skipApkLibDependencies = SettingKey[Boolean]("skip-apklib-dependencies")
 
   val apklibSources = TaskKey[Seq[File]]("apklib-sources", "Enumerate Java sources from apklibs")
   val aaptGenerate = TaskKey[Seq[File]]("aapt-generate", "Generate R.java")

--- a/src/main/scala/AndroidTest.scala
+++ b/src/main/scala/AndroidTest.scala
@@ -23,7 +23,8 @@ object AndroidTest {
     inConfig(Android) (Seq (
       testEmulator <<= instrumentationTestAction(true),
       testDevice <<= instrumentationTestAction(false),
-      skipApkLibDependencies := true
+      skipApkLibDependencies := true,
+      useProguard := false
     )) ++ Seq (
       testEmulator <<= (testEmulator in Android),
       testDevice <<= (testDevice in Android)

--- a/src/main/scala/AndroidTest.scala
+++ b/src/main/scala/AndroidTest.scala
@@ -13,21 +13,15 @@ object AndroidTest {
     }
 
   /** AndroidTestProject */
-  lazy val androidSettings = settings ++
-    inConfig(Android)( Seq(
-      proguardInJars <<= (scalaInstance) map {
-        (scalaInstance) =>
-         Seq(scalaInstance.libraryJar)
-      }
-    )
-  )
+  lazy val androidSettings = settings
 
   lazy val settings: Seq[Setting[_]] =
     AndroidBase.settings ++
     AndroidInstall.settings ++
     inConfig(Android) (Seq (
       testEmulator <<= instrumentationTestAction(true),
-      testDevice <<= instrumentationTestAction(false)
+      testDevice <<= instrumentationTestAction(false),
+      skipApkLibDependencies := true
     )) ++ Seq (
       testEmulator <<= (testEmulator in Android),
       testDevice <<= (testDevice in Android)

--- a/src/main/scala/AndroidTest.scala
+++ b/src/main/scala/AndroidTest.scala
@@ -13,7 +13,9 @@ object AndroidTest {
     }
 
   /** AndroidTestProject */
-  lazy val androidSettings = settings
+  lazy val androidSettings = settings ++ inConfig(Android)(
+    proguardInJars := Seq.empty
+  )
 
   lazy val settings: Seq[Setting[_]] =
     AndroidBase.settings ++


### PR DESCRIPTION
This branch does a couple of things.
1. It fixes runtime errors caused by duplicated/overlapping inclusion of libraries in the main apk and the test apk.  The test apk should only include test-specific content (classes, resources, libraries)
2. It skips proguard on the test project altogether.  Given (1), the need to run proguard on the test project is pretty dramatically reduced.

With this branch, I'm finally able to successfully run some basic `ProviderTestCase2` stuff from sbt.

The downside:  It's a little bit hacky (note the use of the `skipApkLibDependencies` key).
