### PR TITLE
Keep backup agents

### DIFF
--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -86,6 +86,7 @@ object AndroidInstall {
                  "-dontnote org.xml.sax.EntityResolver" ::
                  "-keep public class * extends android.app.Activity" ::
                  "-keep public class * extends android.app.Service" ::
+                 "-keep public class * extends android.app.backup.BackupAgent" ::
                  "-keep public class * extends android.appwidget.AppWidgetProvider" ::
                  "-keep public class * extends android.content.BroadcastReceiver" ::
                  "-keep public class * extends android.content.ContentProvider" ::


### PR DESCRIPTION
Backup agents are typically not referenced directly because of compatibility issues with older Android versions. They are dynamically loaded, or will only be referenced from `AndroidManifest.xml`.

I see more and more of those proguard issues. Maybe we should ensure that all classes referenced from `AndroidManifest.xml` are kept automatically (in addition to those protected explicitly).
