### PR TITLE
Support for .so artifacts in libraryDependencies

### DIFF
--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -142,12 +142,12 @@ object AndroidInstall {
 
     packageConfig <<=
       (toolsPath, packageApkPath, resourcesApkPath, classesDexPath,
-       nativeLibrariesPath, dxInputs, resourceDirectory) map
-      (ApkConfig(_, _, _, _, _, _, _)),
+       nativeLibrariesPath, managedNativePath, dxInputs, resourceDirectory) map
+      (ApkConfig(_, _, _, _, _, _, _, _)),
 
     packageDebug <<= packageTask(true),
     packageRelease <<= packageTask(false)
   ) ++ Seq(packageDebug, packageRelease).map {
-    t => t <<= t dependsOn (cleanApk, aaptPackage)
+    t => t <<= t dependsOn (cleanApk, aaptPackage, copyNativeLibraries)
   })
 }

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -63,6 +63,7 @@ object AndroidKeys {
   val mainAssetsPath = SettingKey[File]("main-asset-path")
   val mainResPath = TaskKey[File]("main-res-path")
   val managedJavaPath = SettingKey[File]("managed-java-path")
+  val managedNativePath = SettingKey[File]("managed-native-path")
   val classesMinJarPath = SettingKey[File]("classes-min-jar-path")
   val classesDexPath = SettingKey[File]("classes-dex-path")
   val resourcesApkPath = SettingKey[File]("resources-apk-path")
@@ -96,6 +97,7 @@ object AndroidKeys {
   case class LibraryProject(pkgName: String, manifest: File, sources: Set[File], resDir: Option[File], assetsDir: Option[File])
 
   val extractApkLibDependencies = TaskKey[Seq[LibraryProject]]("apklib-dependencies", "Unpack apklib dependencies")
+  val copyNativeLibraries = TaskKey[Unit]("copy-native-libraries", "Copy native libraries added to libraryDependencies")
 
   val apklibSources = TaskKey[Seq[File]]("apklib-sources", "Enumerate Java sources from apklibs")
   val aaptGenerate = TaskKey[Seq[File]]("aapt-generate", "Generate R.java")

--- a/src/main/scala/ApkBuilder.scala
+++ b/src/main/scala/ApkBuilder.scala
@@ -9,6 +9,7 @@ case class ApkConfig(
   resourcesApkPath: File,
   classesDexPath: File,
   nativeLibrariesPath: File,
+  managedNativePath: File,
   dexInputs: Seq[File],
   resourceDirectory: File
 )
@@ -45,6 +46,7 @@ class ApkBuilder(project: ApkConfig, debug: Boolean) {
 
     setDebugMode(builder, debug)
     addNativeLibraries(builder, project.nativeLibrariesPath, null)
+    addNativeLibraries(builder, project.managedNativePath, null)
     for (file <- project.dexInputs; if file.isFile)
       addResourcesFromJar(builder, file)
     addSourceFolder(builder, project.resourceDirectory)


### PR DESCRIPTION
The artifacts are expected to end in ".so" and have either the armeabi or armeabi-v7a classifier:

```
addArtifact(Artifact("libgdx", "so", "so", "armeabi"), ...)
```

and they should also be without the scala version cross path when published:

```
crossPaths := false
```

They are copied to a managed native library folder and the ApkBuilder has been modified to add additional native libraries from that folder.

One part I'm not sure about is adding "so" to classpathTypes. There probably needs to be additional work done to make sure only jars in the classpath are being proguarded and such.
