### PR TITLE
fix native libraryDepencies renaming

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -12,7 +12,8 @@ object AndroidBase {
   def getNativeTarget(parent: File, name: String, abi: String) = {
     val extension = "-" + abi + ".so"
     if (name endsWith extension) {
-      val target = new File(abi) / name.replace(extension, ".so")
+      val stripped = name.substring(0, name indexOf '-') + ".so"
+      val target = new File(abi) / stripped
       Some(parent / target.toString)
     } else None
   }


### PR DESCRIPTION
For example: in libgdx-svn-SNAPSHOT-armeabi.so, I was chopping off the -armeabi tag but not the -svn-SNAPSHOT. Now I'm only using the name until the first '-'. This isn't ideal, but hopefully noone uses hyphens in their .so names (underscores are standard...)

Your last patch excluding .so's from proguard seems to be a winner.
