### PR TITLE
Tell ProGuard to preserve serialization hooks.  (re: issue 122)

### DIFF
--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -94,6 +94,15 @@ object AndroidInstall {
                  "-keep public class * extends android.app.Application" ::
                  "-keep public class "+manifestPackage+".** { public protected *; }" ::
                  "-keep public class * implements junit.framework.Test { public void test*(); }" ::
+                 """
+                  -keepclassmembers class * implements java.io.Serializable {
+                    private static final java.io.ObjectStreamField[] serialPersistentFields;
+                    private void writeObject(java.io.ObjectOutputStream);
+                    private void readObject(java.io.ObjectInputStream);
+                    java.lang.Object writeReplace();
+                    java.lang.Object readResolve();
+                   }
+                   """ ::
                  proguardOption :: Nil )
           val config = new ProGuardConfiguration
           new ConfigurationParser(args.toArray[String]).parse(config)


### PR DESCRIPTION
Without specific notice, ProGuard will lop off readObject, readResolve, etc.,
which can lead to baffling failures, even when just serializing library
classes.  For example, if you're serializing Scala Option[T] objects, losing
readResolve can get you duplicates of None, which is ordinarily a singleton;
that, in turn, can lead to spurious, and very strange-looking MatchExceptions.
