### PR TITLE
more precise control and verbose logging for proguard task

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -193,7 +193,31 @@ object AndroidBase {
     jarPath <<= (platformPath, jarName) (_ / _),
     libraryJarPath <<= (jarPath (_ get)),
 
-    proguardOption := "",
+    proguardOption <<= (manifestPackage) map {
+      (manifestPackage) =>
+                ("-dontwarn" :: "-dontobfuscate" ::
+                 "-dontnote scala.Enumeration" ::
+                 "-dontnote org.xml.sax.EntityResolver" ::
+                 "-keep public class * extends android.app.Activity" ::
+                 "-keep public class * extends android.app.Service" ::
+                 "-keep public class * extends android.app.backup.BackupAgent" ::
+                 "-keep public class * extends android.appwidget.AppWidgetProvider" ::
+                 "-keep public class * extends android.content.BroadcastReceiver" ::
+                 "-keep public class * extends android.content.ContentProvider" ::
+                 "-keep public class * extends android.view.View" ::
+                 "-keep public class * extends android.app.Application" ::
+                 "-keep public class "+manifestPackage+".** { public protected *; }" ::
+                 "-keep public class * implements junit.framework.Test { public void test*(); }" ::
+                 """
+                  -keepclassmembers class * implements java.io.Serializable {
+                    private static final java.io.ObjectStreamField[] serialPersistentFields;
+                    private void writeObject(java.io.ObjectOutputStream);
+                    private void readObject(java.io.ObjectInputStream);
+                    java.lang.Object writeReplace();
+                    java.lang.Object readResolve();
+                   }
+                   """ :: Nil)
+    },
     proguardExclude <<= (libraryJarPath, classDirectory, resourceDirectory) map {
         (libPath, classDirectory, resourceDirectory) =>
           libPath :+ classDirectory :+ resourceDirectory

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -110,9 +110,9 @@ object AndroidInstall {
 
   private def proguardTask: Project.Initialize[Task[Option[File]]] =
     (useProguard, proguardOptimizations, classDirectory, proguardInJars, streams,
-     classesMinJarPath, libraryJarPath, manifestPackage, proguardOption) map {
+     classesMinJarPath, libraryJarPath, proguardOption) map {
     (useProguard, proguardOptimizations, classDirectory, proguardInJars, streams,
-     classesMinJarPath, libraryJarPath, manifestPackage, proguardOption) =>
+     classesMinJarPath, libraryJarPath, proguardOption) =>
       if (useProguard) {
           val optimizationOptions = if (proguardOptimizations.isEmpty) Seq("-dontoptimize") else proguardOptimizations
           val manifestr = List("!META-INF/MANIFEST.MF", "R.class", "R$*.class",
@@ -125,31 +125,8 @@ object AndroidInstall {
                  "-injars" :: inJars.mkString(sep) ::
                  "-outjars" :: "\""+classesMinJarPath.absolutePath+"\"" ::
                  "-libraryjars" :: libraryJarPath.map("\""+_+"\"").mkString(sep) ::
-                 Nil) ++
-                 optimizationOptions ++ (
-                 "-dontwarn" :: "-dontobfuscate" ::
-                 "-dontnote scala.Enumeration" ::
-                 "-dontnote org.xml.sax.EntityResolver" ::
-                 "-keep public class * extends android.app.Activity" ::
-                 "-keep public class * extends android.app.Service" ::
-                 "-keep public class * extends android.app.backup.BackupAgent" ::
-                 "-keep public class * extends android.appwidget.AppWidgetProvider" ::
-                 "-keep public class * extends android.content.BroadcastReceiver" ::
-                 "-keep public class * extends android.content.ContentProvider" ::
-                 "-keep public class * extends android.view.View" ::
-                 "-keep public class * extends android.app.Application" ::
-                 "-keep public class "+manifestPackage+".** { public protected *; }" ::
-                 "-keep public class * implements junit.framework.Test { public void test*(); }" ::
-                 """
-                  -keepclassmembers class * implements java.io.Serializable {
-                    private static final java.io.ObjectStreamField[] serialPersistentFields;
-                    private void writeObject(java.io.ObjectOutputStream);
-                    private void readObject(java.io.ObjectInputStream);
-                    java.lang.Object writeReplace();
-                    java.lang.Object readResolve();
-                   }
-                   """ ::
-                 proguardOption :: Nil )
+                 Nil) ++ optimizationOptions ++ proguardOption
+          streams.log.debug("executing proguard: " + (for (i <- 0 until args.size) yield {"arg" + (i + 1) + ": " + args(i)}).mkString("\n"))
           val config = new ProGuardConfiguration
           new ConfigurationParser(args.toArray[String]).parse(config)
           streams.log.debug("executing proguard: "+args.mkString("\n"))

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -16,7 +16,7 @@ object AndroidKeys {
   val versionName = TaskKey[String]("version-name")
 
   /** Proguard Settings */
-  val proguardOption = SettingKey[String]("proguard-option")
+  val proguardOption = TaskKey[Seq[String]]("proguard-option")
   val proguardOptimizations = SettingKey[Seq[String]]("proguard-optimizations")
   val libraryJarPath = SettingKey[Seq[File]]("library-path")
 


### PR DESCRIPTION
we may add our proguard.cfg settings to proguardOptions with

```
proguardOption in Android <+= (baseDirectory) map { (b) => scala.io.Source.fromFile(b / "proguard.cfg").mkString }
```

or we may completely override proguardOptions with

```
proguardOption in Android <<= (baseDirectory) map { (b) => scala.io.Source.fromFile(b / "proguard.cfg").mkString :: Nil }
```

also add more verbose logging

[debug] executing proguard: arg1: -injars
[debug] arg2: "/hom....
[debug] arg3: -outjars
[debug] arg4: "/home/devbox/android/android-DigiLib/test/testPublicProperties/bin/target/classes.min.jar"
[debug] arg5: -libraryjars
[debug] arg6: "/home/devbox/android/android-sdk-linux/platforms/android-10/android.jar"
[debug] arg7: -dontoptimize

it is handy to fix errors like

```
android:proguard: proguard.ParseException: NNNNN in argument number 20
```
