### PR TITLE
Upgrade to ProGuard 4.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
 libraryDependencies ++= Seq(
   "com.google.android.tools" % "ddmlib" % "r10",
-  "net.sf.proguard" % "proguard-base" % "4.6"
+  "net.sf.proguard" % "proguard-base" % "4.8"
 )
 
 sbtPlugin := true

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -1,3 +1,4 @@
+import java.util.Properties
 import proguard.{Configuration=>ProGuardConfiguration, ProGuard, ConfigurationParser}
 
 import sbt._
@@ -151,7 +152,7 @@ object AndroidInstall {
                    """ ::
                  proguardOption :: Nil )
           val config = new ProGuardConfiguration
-          new ConfigurationParser(args.toArray[String]).parse(config)
+          new ConfigurationParser(args.toArray[String], new Properties).parse(config)
           streams.log.debug("executing proguard: "+args.mkString("\n"))
           new ProGuard(config).execute
           Some(classesMinJarPath)


### PR DESCRIPTION
ProGuard 4.8 is now in Maven Central, so this is fairly easy:

http://search.maven.org/#artifactdetails%7Cnet.sf.proguard%7Cproguard-base%7C4.8%7Cjar

Between ProGuard 4.7 and 4.8 there was a small change to the constructor of proguard.ConfigurationParser to allow updating 'external references' in file names ('<...>') with a supplied set of properties. I've supplied a blank Properties object here to get the code compiling.
