### PR TITLE
fix travis settings. support sbt 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: scala
+
+script: wget https://raw.github.com/paulp/sbt-extras/master/sbt && chmod u+x ./sbt && ./sbt -mem 512 test
+


### PR DESCRIPTION
recently travis tests fail
- http://travis-ci.org/#!/jberkel/android-plugin/builds/2124889
- http://travis-ci.org/#!/jberkel/android-plugin/builds/2125152

because travis-ci default sbt-launch.jar version is 0.11.3. not support sbt 0.12
but we can use custom scripts.
