### PR TITLE
Support for creating and publishing apklib (library projects)

### DIFF
--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -39,6 +39,7 @@ object AndroidKeys {
 
   /** Determined Settings */
   val packageApkName = TaskKey[String]("package-apk-name")
+  val packageApkLibName = TaskKey[String]("package-apklib-name")
   val osDxName = SettingKey[String]("os-dx-name")
 
   /** Path Settings */
@@ -68,6 +69,7 @@ object AndroidKeys {
   val classesDexPath = SettingKey[File]("classes-dex-path")
   val resourcesApkPath = SettingKey[File]("resources-apk-path")
   val packageApkPath = TaskKey[File]("package-apk-path")
+  val packageApkLibPath = TaskKey[File]("package-apklib-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
 
   /** Install Settings */
@@ -96,6 +98,7 @@ object AndroidKeys {
   /** Base Tasks */
   case class LibraryProject(pkgName: String, manifest: File, sources: Set[File], resDir: Option[File], assetsDir: Option[File])
 
+  val apklibPackage = TaskKey[File]("apklib-package")
   val extractApkLibDependencies = TaskKey[Seq[LibraryProject]]("apklib-dependencies", "Unpack apklib dependencies")
   val copyNativeLibraries = TaskKey[Unit]("copy-native-libraries", "Copy native libraries added to libraryDependencies")
 


### PR DESCRIPTION
There is a new apklibPackage task. To use it, concatenate something like the following to your settings:

```
addArtifact(Artifact("facebook-android-sdk", "apklib", "apklib"), apklibPackage in Android).settings
```

(I'm using it to produce an apklib package of the facebook SDK internally.)

Then the apklib will be built with:

```
sbt publish-local
```

or:

```
sbt publish
```

I think that this can be adapted to restore dependsOn functionality to library projects, but that's a project for another day!

Note that only the apklib features supported on the dependency side are supported on the creation side by this patch. Namely, jar libraries dependencies and ndk libraries are not included in the apklib.
