### PR TITLE
Add resPath task to allow specifying additional resource directories

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -108,14 +108,10 @@ object AndroidBase {
     }
 
   private def aaptGenerateTask =
-    (manifestPackage, aaptPath, manifestPath, mainResPath, jarPath, managedJavaPath, extractApkLibDependencies, streams) map {
-    (mPackage, aPath, mPath, resPath, jPath, javaPath, apklibs, s) =>
+    (manifestPackage, aaptPath, manifestPath, resPath, jarPath, managedJavaPath, extractApkLibDependencies, streams) map {
+    (mPackage, aPath, mPath, rPath, jPath, javaPath, apklibs, s) =>
 
-    val libraryResPathArgs = for (
-      lib <- apklibs;
-      d <- lib.resDir.toSeq;
-      arg <- Seq("-S", d.absolutePath)
-    ) yield arg
+    val libraryResPathArgs = rPath.flatMap(p => Seq("-S", p.absolutePath))
 
     val libraryAssetPathArgs = for (
       lib <- apklibs;
@@ -127,7 +123,6 @@ object AndroidBase {
       val aapt = Seq(aPath.absolutePath, "package", "--auto-add-overlay", "-m",
         "--custom-package", `package`,
         "-M", mPath.head.absolutePath,
-        "-S", resPath.absolutePath,
         "-I", jPath.absolutePath,
         "-J", javaPath.absolutePath) ++
         args ++

--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -196,6 +196,10 @@ object AndroidBase {
     managedScalaPath <<= (sourceManaged in Compile) ( _ / "scala"),
     managedNativePath <<= (sourceManaged in Compile) (_ / "native_libs"),
 
+    resPath := Seq(),
+    resPath <+= mainResPath,
+    resPath <++= extractApkLibDependencies map (apklibs => apklibs.flatMap(_.resDir)),
+
     extractApkLibDependencies <<= apklibDependenciesTask,
     apklibPackage <<= apklibPackageTask,
 

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -19,18 +19,13 @@ object AndroidInstall {
   }
 
   private def aaptPackageTask: Project.Initialize[Task[File]] =
-  (aaptPath, manifestPath, mainResPath, mainAssetsPath, jarPath, resourcesApkPath, extractApkLibDependencies, streams) map {
-    (apPath, manPath, rPath, assetPath, jPath, resApkPath, apklibs, s) =>
+  (aaptPath, manifestPath, resPath, mainAssetsPath, jarPath, resourcesApkPath, streams) map {
+    (apPath, manPath, rPath, assetPath, jPath, resApkPath, s) =>
 
-    val libraryResPathArgs = for (
-      lib <- apklibs;
-      d <- lib.resDir.toSeq;
-      arg <- Seq("-S", d.absolutePath)
-    ) yield arg
+    val libraryResPathArgs = rPath.flatMap(p => Seq("-S", p.absolutePath))
 
     val aapt = Seq(apPath.absolutePath, "package", "--auto-add-overlay", "-f",
         "-M", manPath.head.absolutePath,
-        "-S", rPath.absolutePath,
         "-A", assetPath.absolutePath,
         "-I", jPath.absolutePath,
         "-F", resApkPath.absolutePath) ++

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -71,6 +71,7 @@ object AndroidKeys {
   val packageApkPath = TaskKey[File]("package-apk-path")
   val packageApkLibPath = TaskKey[File]("package-apklib-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
+  val resPath = TaskKey[Seq[File]]("res-path")
 
   /** Install Settings */
   val packageConfig = TaskKey[ApkConfig]("package-config",


### PR DESCRIPTION
I need to integrate tool which generates resources. However, resource directory list is hardcoded inside `aaptGenerateTask` and `aaptPackageTask` to be main resource directory plus resource directories from referenced library projects.

This change extracts resource directory list into `res-path` task which can be modified. It contains main resource directory and ones from library projects by default.
