### PR TITLE
Add option to preserve service registry

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -207,6 +207,10 @@ object AndroidBase {
     useProguard := true,
     proguardOptimizations := Seq.empty,
 
+    preserveServiceRegistry := false,
+    serviceRegistryInclude := Seq(".*"),
+    serviceRegistryExclude := Seq.empty,
+
     jarPath <<= (platformPath, jarName) (_ / _),
     libraryJarPath <<= (jarPath (_ get)),
 

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -72,6 +72,10 @@ object AndroidKeys {
   val packageApkLibPath = TaskKey[File]("package-apklib-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
 
+  val preserveServiceRegistry = SettingKey[Boolean]("preserve-service-registry")
+  val serviceRegistryInclude = SettingKey[Seq[String]]("service-registry-include")
+  val serviceRegistryExclude = SettingKey[Seq[String]]("service-registry-exclude")
+
   /** Install Settings */
   val packageConfig = TaskKey[ApkConfig]("package-config",
     "Generates a Apk Config")
@@ -81,7 +85,7 @@ object AndroidKeys {
   val typedResource = TaskKey[File]("typed-resource",
     """Typed resource file to be generated, also includes
        interfaces to access these resources.""")
-  val layoutResources = TaskKey[Seq[File]]("layout-resources", 
+  val layoutResources = TaskKey[Seq[File]]("layout-resources",
       """All files that are in res/layout. They will
 		 be accessable through TR.layouts._""")
 


### PR DESCRIPTION
Add preserveServiceRegistry, serviceRegistryInclude &
serviceRegistryExclude keys.

When preserveServiceRegistry is true, files in META-INF/services
will be merged, filtered and then insert into the final apk.

Any class name that match any regexp in serviceRegistryInclude and
not match any regexp in serviceRegistryExclude will be included.
