### PR TITLE
Add proguard custom '-injars' parameter and filtering in jar files from the '-injars' parameter

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -206,6 +206,8 @@ object AndroidBase {
     resourcesApkPath <<= (target, resourcesApkName) (_ / _),
     useProguard := true,
     proguardOptimizations := Seq.empty,
+    proguardInJarsOption := Seq.empty,
+    proguardInJarsFilter := { case _ => Seq.empty},
 
     jarPath <<= (platformPath, jarName) (_ / _),
     libraryJarPath <<= (jarPath (_ get)),

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -16,6 +16,8 @@ object AndroidKeys {
   val versionName = TaskKey[String]("version-name")
 
   /** Proguard Settings */
+  val proguardInJarsFilter = TaskKey[PartialFunction[String, Seq[String]]]("proguard-injars-filter")
+  val proguardInJarsOption = TaskKey[Seq[String]]("proguard-injars-option")
   val proguardOption = SettingKey[String]("proguard-option")
   val proguardOptimizations = SettingKey[Seq[String]]("proguard-optimizations")
   val libraryJarPath = SettingKey[Seq[File]]("library-path")


### PR DESCRIPTION
## Summary

Sometimes you have to pack resources from input jars differently in the Proguard output. For that case this patch provides for adding additional unfiltered jars as input to proguard (which is currently not easily possible with the way the `proguardInJars` is used) and also allows for custom filtering of the content of specific injars.
## Documentation
### Modification of the input to ProGuard

By default the plugin filters out the Manifest and generated resource classes from ProGuard input. If you need to filter out more resources, you can specify them in `proguardInJarsFilter` as a partial function. The partial function takes the injar element as input and can return additional ProGuard filter expressions for this jar. If the partial function does not match, only the above default filtering is applied.
For example, you can match on the akka jars and exclude reference.conf from the ProGuard input to avoid the duplicate resource issue.

```
val AkkaReg = """.*akka.*\.jar""".r
proguardInJarsFilter := { case AkkaReg() => Seq("!reference.conf") }
```

If you have further jars or other content to feed _unfiltered_ into ProGuard, you can specify them in `proguardInJarsOption`.

```
proguardInJarsOption += "path/to/my/resource"
```
## Related

There is a related pull request https://github.com/jberkel/android-plugin/pull/150 which implements the filtering slightly different and misses the ability to add unfiltered injars.
