### PR TITLE
Fix typo in apklibPackageTask

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -67,7 +67,7 @@ object AndroidBase {
         (PathFinder(jPath) ** "*.java"  x rebase(jPath, "src")) ++
         (PathFinder(sPath) ** "*.scala" x rebase(sPath, "src")) ++
         ((PathFinder(rPath) ***)        x rebase(rPath, "res")) ++
-        ((PathFinder(aPath) ***)        x rebase(rPath, "assets"))
+        ((PathFinder(aPath) ***)        x rebase(aPath, "assets"))
       IO.jar(mapping, apklib, new java.util.jar.Manifest)
       apklib
     }


### PR DESCRIPTION
Fix wrong base passed to `rebase` for "assets" directory mapping in `apklibPackageTask`.
