### PR TITLE
Add setting to control the inclusion of Scala libs in the APK

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -205,6 +205,7 @@ object AndroidBase {
     classesDexPath <<= (target, classesDexName) (_ / _),
     resourcesApkPath <<= (target, resourcesApkName) (_ / _),
     useProguard := true,
+    skipScalaLibrary := false,
     proguardOptimizations := Seq.empty,
 
     jarPath <<= (platformPath, jarName) (_ / _),

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -71,6 +71,7 @@ object AndroidKeys {
   val packageApkPath = TaskKey[File]("package-apk-path")
   val packageApkLibPath = TaskKey[File]("package-apklib-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
+  val skipScalaLibrary = SettingKey[Boolean]("skip-scala-library")
 
   /** Install Settings */
   val packageConfig = TaskKey[ApkConfig]("package-config",


### PR DESCRIPTION
After all that free advertising Facebook decided to give to our favorite Dalvik issue, I just learned that it had been fixed in recent versions of Android. Therefore, no more Proguard for development on Android 4.1+, which is amazing news!

Unfortunately the `android-plugin` absolutely wanted to skip the inclusion of the Scala libs in the generated APK when disabling Proguard. I added a setting key (`skip-scala-library`) to control that.

The default is "Use Proguard" and "Include Scala" (i.e. `useProguard := true` and `skipScalaLibrary := false`), which I believe is should work for most people.
