### PR TITLE
Simplify settings for library predexing

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -205,6 +205,7 @@ object AndroidBase {
     classesDexPath <<= (target, classesDexName) (_ / _),
     resourcesApkPath <<= (target, resourcesApkName) (_ / _),
     useProguard := true,
+    skipScalaLibrary := false,
     proguardOptimizations := Seq.empty,
 
     jarPath <<= (platformPath, jarName) (_ / _),

--- a/src/main/scala/AndroidDefault.scala
+++ b/src/main/scala/AndroidDefault.scala
@@ -32,6 +32,7 @@ object AndroidDefaults {
     classesDexName := DefaultClassesDexName,
     resourcesApkName := DefaultResourcesApkName,
     dxOpts := DefaultDxOpts,
+    predexLibraries := false,
     manifestSchema := DefaultManifestSchema,
     envs := DefaultEnvs,
     // a list of modules which are already included in Android

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -71,6 +71,7 @@ object AndroidKeys {
   val packageApkPath = TaskKey[File]("package-apk-path")
   val packageApkLibPath = TaskKey[File]("package-apklib-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
+  val skipScalaLibrary = SettingKey[Boolean]("skip-scala-library")
 
   /** Install Settings */
   val packageConfig = TaskKey[ApkConfig]("package-config",

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -72,6 +72,7 @@ object AndroidKeys {
   val packageApkLibPath = TaskKey[File]("package-apklib-path")
   val useProguard = SettingKey[Boolean]("use-proguard")
   val skipScalaLibrary = SettingKey[Boolean]("skip-scala-library")
+  val predexLibraries = SettingKey[Boolean]("predex-libraries")
 
   /** Install Settings */
   val packageConfig = TaskKey[ApkConfig]("package-config",


### PR DESCRIPTION
I thought the code handling predexing for the second parameter of `dxOpts` was not very straightforward. I replaced it with my own setting key toggling predexing for every library input.

Basically, if `predexLibraries` is `false`, then run `dxTask` as before, else predex every `file.jar` input as a `file.jar.apk` predexed cache that won't be rebuilt unless the origin JAR has changed, then link them to the compiled classes.
