### PR TITLE
[fix] Emulator preloading, added library version

### DIFF
--- a/src/main/scala/Android.scala
+++ b/src/main/scala/Android.scala
@@ -48,6 +48,7 @@ object AndroidProject extends Plugin {
 
   lazy val androidSettings: Seq[Setting[_]] =
     AndroidBase.settings ++
+    AndroidPreload.settings ++
     AndroidLaunch.settings ++
     AndroidDdm.settings
 

--- a/src/main/scala/AndroidHelpers.scala
+++ b/src/main/scala/AndroidHelpers.scala
@@ -24,14 +24,19 @@ object AndroidHelpers {
   def usesSdk(mpath: File, schema: String, key: String) =
     (manifest(mpath) \ "uses-sdk").head.attribute(schema, key).map(_.text.toInt)
 
-  def adbTask(dPath: String, emulator: Boolean, s: TaskStreams, action: String*) {
+  def adbTask(dPath: String, emulator: Boolean, s: TaskStreams, action: String*) = {
     val (exit, out) = adbTaskWithOutput(dPath, emulator, s, action:_*)
+
+    // Check exit value
     if (exit != 0 ||
         // adb doesn't bother returning a non-zero exit code on failure
         out.toString.contains("Failure")) {
       s.log.error(out.toString)
       sys.error("error executing adb")
-    } else s.log.info(out.toString)
+    } else s.log.debug(out.toString)
+
+    // Return output
+    out.toString
   }
 
   def adbTaskWithOutput(dPath: String, emulator: Boolean, s: TaskStreams, action: String*) = {

--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -12,10 +12,12 @@ object AndroidInstall {
 
   private def installTask(emulator: Boolean) = (dbPath, packageApkPath, streams) map { (dp, p, s) =>
     adbTask(dp.absolutePath, emulator, s, "install", "-r ", p.absolutePath)
+    ()
   }
 
   private def uninstallTask(emulator: Boolean) = (dbPath, manifestPackage, streams) map { (dp, m, s) =>
     adbTask(dp.absolutePath, emulator, s, "uninstall", m)
+    ()
   }
 
   private def aaptPackageTask: Project.Initialize[Task[File]] =

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -201,14 +201,12 @@ object AndroidKeys {
   val remountEmulator = TaskKey[Unit]("remount-emulator")
 
   /** Install Scala on device/emulator **/
-  val preloadedDevice   = TaskKey[Option[String]]("preloaded-device", "The version of Scala currently on the device")
-  val preloadedEmulator = TaskKey[Option[String]]("preloaded-emulator", "The version of Scala currently on the emulator")
   val preloadDevice     = TaskKey[Unit]("preload-device", "Setup device for development by uploading the predexed Scala library")
-  val preloadEmulator   = TaskKey[Unit]("preload-emulator", "Setup emulator for development by uploading the predexed Scala library")
+  val preloadEmulator   = InputKey[Unit]("preload-emulator", "Setup emulator for development by uploading the predexed Scala library")
 
   /** Unload Scala from device/emulator **/
   val unloadDevice   = TaskKey[Unit]("unload-device", "Unloads the Scala library from the device")
-  val unloadEmulator = TaskKey[Unit]("unload-emulator", "Unloads the Scala library from the emulator")
+  val unloadEmulator = InputKey[Unit]("unload-emulator", "Unloads the Scala library from the emulator")
 
   /** Use preloaded Scala for development **/
   val usePreloadedScala = SettingKey[Boolean]("use-preloaded-scala",

--- a/src/main/scala/AndroidLaunch.scala
+++ b/src/main/scala/AndroidLaunch.scala
@@ -13,6 +13,7 @@ object AndroidLaunch {
               emulator, s,
               "shell", "am", "start", "-a", "android.intent.action.MAIN",
               "-n", mPackage+"/"+launcherActivity(schema, amPath.head, mPackage))
+      ()
   }
 
   private def launcherActivity(schema: String, amPath: File, mPackage: String) = {


### PR DESCRIPTION
This is a fix for emulator preloading, now works without any issue, at least on my side :

```
> sbt
Loading project definition from /Users/fx/Documents/Projects/Lunar/project
[info] Set current project to Lunar (in build file:/Users/fx/Documents/Projects/Lunar/)

> android:preload-emulator Galaxy_Nexus_HAXM
[info] Starting emulator with read-write system
[info] This may take a while...
Warning: No DNS servers found
HAX is working and emulator runs in fast virt mode
[info] Installing scala-library.2.10.0.jar
[info] Setting permissions for scala-library.2.10.0.jar
[success] Total time: 31 s, completed Mar 15, 2013 10:52:20 PM

> android:emulator-start Galaxy_Nexus_HAXM
[success] Total time: 0 s, completed Mar 15, 2013 10:52:31 PM

> android:start-emulator
[info] Wrote /Users/fx/Documents/Projects/Lunar/target/scala-2.10/src_managed/main/scala/com/github/fxthomas/lunar/TR.scala
[info] Skipping Proguard
[info] Packaging /Users/fx/Documents/Projects/Lunar/target/lunar-0.1.apk
[success] Total time: 4 s, completed Mar 15, 2013 10:53:35 PM
```
