### PR TITLE
generate TypedResources from all layout folders

### DIFF
--- a/src/main/scala/TypedResources.scala
+++ b/src/main/scala/TypedResources.scala
@@ -111,7 +111,10 @@ object TypedResources {
     typedResource <<= (manifestPackage, managedScalaPath) map {
       _.split('.').foldLeft(_) ((p, s) => p / s) / "TR.scala"
     },
-    layoutResources <<= (mainResPath) map { x=>  (x / "layout" ** "*.xml" get) },
+    layoutResources <<= (mainResPath) map { x=>
+      (x ** "layout*" get)
+        .flatMap(_ ** "*.xml" get)
+    },
 
     generateTypedResources <<= generateTypedResourcesTask,
 


### PR DESCRIPTION
Search all "layout*" folders for xml files.

Useful for case when you have resources for different configurations as "layout" and "layout-land"
