### PR TITLE
Added a workaround for ADB over network

### DIFF
--- a/src/main/scala/AndroidInstall.scala
+++ b/src/main/scala/AndroidInstall.scala
@@ -10,13 +10,13 @@ import java.io.{File => JFile}
 
 object AndroidInstall {
 
-  private def installTask(emulator: Boolean) = (dbPath, packageApkPath, streams) map { (dp, p, s) =>
-    adbTask(dp.absolutePath, emulator, s, "install", "-r ", p.absolutePath)
+  private def installTask(androidTarget: Symbol) = (dbPath, packageApkPath, streams) map { (dp, p, s) =>
+    adbTask(dp.absolutePath, androidTarget, s, "install", "-r ", p.absolutePath)
     ()
   }
 
-  private def uninstallTask(emulator: Boolean) = (dbPath, manifestPackage, streams) map { (dp, m, s) =>
-    adbTask(dp.absolutePath, emulator, s, "uninstall", m)
+  private def uninstallTask(androidTarget: Symbol) = (dbPath, manifestPackage, streams) map { (dp, m, s) =>
+    adbTask(dp.absolutePath, androidTarget, s, "uninstall", m)
     ()
   }
 
@@ -156,13 +156,15 @@ object AndroidInstall {
   }
 
   lazy val installerTasks = Seq (
-    installEmulator <<= installTask(emulator = true) dependsOn packageDebug,
-    installDevice <<= installTask(emulator = false) dependsOn packageDebug
+    installAny <<= installTask(androidTarget = 'any) dependsOn packageDebug,
+    installEmulator <<= installTask(androidTarget = 'emulator) dependsOn packageDebug,
+    installDevice <<= installTask(androidTarget = 'device) dependsOn packageDebug
   )
 
   lazy val settings: Seq[Setting[_]] = inConfig(Android) (installerTasks ++ Seq (
-    uninstallEmulator <<= uninstallTask(emulator = true),
-    uninstallDevice <<= uninstallTask(emulator = false),
+    uninstallAny <<= uninstallTask(androidTarget = 'any),
+    uninstallEmulator <<= uninstallTask(androidTarget = 'emulator),
+    uninstallDevice <<= uninstallTask(androidTarget = 'device),
 
     makeAssetPath <<= directory(mainAssetsPath),
 

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -84,7 +84,7 @@ object AndroidKeys {
   val typedResource = TaskKey[File]("typed-resource",
     """Typed resource file to be generated, also includes
        interfaces to access these resources.""")
-  val layoutResources = TaskKey[Seq[File]]("layout-resources", 
+  val layoutResources = TaskKey[Seq[File]]("layout-resources",
       """All files that are in res/layout. They will
 		 be accessable through TR.layouts._""")
 
@@ -116,6 +116,9 @@ object AndroidKeys {
   val makeManagedJavaPath = TaskKey[Unit]("make-managed-java-path")
 
   /** Installable Tasks */
+  val installAny = TaskKey[Unit]("install-any")
+  val uninstallAny = TaskKey[Unit]("uninstall-any")
+
   val installEmulator = TaskKey[Unit]("install-emulator")
   val uninstallEmulator = TaskKey[Unit]("uninstall-emulator")
 
@@ -136,6 +139,8 @@ object AndroidKeys {
   val makeAssetPath = TaskKey[Unit]("make-assest-path")
 
   /** Launch Tasks */
+  val startAny = TaskKey[Unit]("start-any",
+    "Start package on any Android platform after installation")
   val startDevice = TaskKey[Unit]("start-device",
     "Start package on device after installation")
   val startEmulator = TaskKey[Unit]("start-emulator",
@@ -144,17 +149,23 @@ object AndroidKeys {
   /** ddm Support tasks */
   val stopBridge = TaskKey[Unit]("stop-bridge",
     "Terminates the ADB debugging bridge")
+  val screenshotAny = TaskKey[File]("screenshot-any",
+    "Take a screenshot from any Android platform")
   val screenshotEmulator = TaskKey[File]("screenshot-emulator",
     "Take a screenshot from the emulator")
   val screenshotDevice = TaskKey[File]("screenshot-device",
     "Take a screenshot from the device")
 
   // hprof tasks are Unit because of async nature
+  val hprofAny = TaskKey[Unit]("hprof-any",
+    "Take a dump of the current heap from any Android platform")
   val hprofEmulator = TaskKey[Unit]("hprof-emulator",
     "Take a dump of the current heap from the emulator")
   val hprofDevice = TaskKey[Unit]("hprof-device",
     "Take a dump of the current heap from the device")
 
+  val threadsAny = InputKey[Unit]("threads-any",
+    "Show thread dump from any Android platform")
   val threadsEmulator = InputKey[Unit]("threads-emulator",
     "Show thread dump from the emulator")
   val threadsDevice = InputKey[Unit]("threads-device",
@@ -181,8 +192,10 @@ object AndroidKeys {
 
   /** Test Project Tasks */
   val testRunner       = TaskKey[String]("test-runner", "get the current test runner")
+  val testAny          = TaskKey[Unit]("test-any", "runs the tests on any Android platform")
   val testEmulator     = TaskKey[Unit]("test-emulator", "runs tests in emulator")
   val testDevice       = TaskKey[Unit]("test-device",   "runs tests on device")
+  val testOnlyAny      = InputKey[Unit]("test-only-any", "run a single test on any Android platform")
   val testOnlyEmulator = InputKey[Unit]("test-only-emulator", "run a single test on emulator")
   val testOnlyDevice   = InputKey[Unit]("test-only-device",   "run a single test on device")
 
@@ -195,16 +208,20 @@ object AndroidKeys {
   val clearPasswords = TaskKey[Unit]("clear-passwords", "Clear cached passwords")
 
   /** Advanced device manipulations **/
+  val rootAny = TaskKey[Unit]("root-any")
+  val remountAny = TaskKey[Unit]("remount-any")
   val rootDevice = TaskKey[Unit]("root-device")
   val remountDevice = TaskKey[Unit]("remount-device")
   val rootEmulator = TaskKey[Unit]("root-emulator")
   val remountEmulator = TaskKey[Unit]("remount-emulator")
 
   /** Install Scala on device/emulator **/
+  val preloadAny        = TaskKey[Unit]("preload-Any", "Setup any Android platform for development by uploading the predexed Scala library")
   val preloadDevice     = TaskKey[Unit]("preload-device", "Setup device for development by uploading the predexed Scala library")
   val preloadEmulator   = InputKey[Unit]("preload-emulator", "Setup emulator for development by uploading the predexed Scala library")
 
   /** Unload Scala from device/emulator **/
+  val unloadAny   = TaskKey[Unit]("unload-Any", "Unloads the Scala library from any Android Platform")
   val unloadDevice   = TaskKey[Unit]("unload-device", "Unloads the Scala library from the device")
   val unloadEmulator = InputKey[Unit]("unload-emulator", "Unloads the Scala library from the emulator")
 

--- a/src/main/scala/AndroidLaunch.scala
+++ b/src/main/scala/AndroidLaunch.scala
@@ -6,11 +6,11 @@ import AndroidHelpers._
 
 object AndroidLaunch {
 
-  private def startTask(emulator: Boolean) =
+  private def startTask(androidTarget: Symbol) =
     (dbPath, manifestSchema, manifestPackage, manifestPath, streams) map {
       (dp, schema, mPackage, amPath, s) =>
       adbTask(dp.absolutePath,
-              emulator, s,
+              androidTarget, s,
               "shell", "am", "start", "-a", "android.intent.action.MAIN",
               "-n", mPackage+"/"+launcherActivity(schema, amPath.head, mPackage))
       ()
@@ -34,9 +34,11 @@ object AndroidLaunch {
   lazy val settings: Seq[Setting[_]] =
     AndroidInstall.settings ++
     inConfig(Android) (Seq (
-      startDevice <<= startTask(false),
-      startEmulator <<= startTask(true),
+      startAny <<= startTask('any),
+      startDevice <<= startTask('device),
+      startEmulator <<= startTask('emulator),
 
+      startAny <<= startAny dependsOn installAny,
       startDevice <<= startDevice dependsOn installDevice,
       startEmulator <<= startEmulator dependsOn installEmulator
     ))

--- a/src/main/scala/AndroidPreload.scala
+++ b/src/main/scala/AndroidPreload.scala
@@ -2,6 +2,7 @@ import sbt._
 import Keys._
 import AndroidKeys._
 import AndroidHelpers._
+import scala.xml.XML
 
 object AndroidPreload {
 
@@ -14,17 +15,17 @@ object AndroidPreload {
   private def devicePermissionPath(ver: String) =
     "/system/etc/permissions/scala-library-" + ver + ".xml"
 
-  private def deviceDesignation(implicit emulator: Boolean) =
-    if (emulator) "emulator" else "device"
+  private def deviceDesignation(implicit androidTarget: Symbol) =
+    if (androidTarget == 'emulator) "emulator" else if(androidTarget == 'device) "device" else "any"
 
   /****************
    * State checks *
    ****************/
 
-  private def checkFileExists (db: File, s: TaskStreams, filename: String)(implicit emulator: Boolean) = {
+  private def checkFileExists (db: File, s: TaskStreams, filename: String)(implicit androidTarget: Symbol) = {
 
     // Run the `ls` command on the device/emulator
-    val flist = adbTask(db.absolutePath, emulator, s,
+    val flist = adbTask(db.absolutePath, androidTarget, s,
       "shell", "ls", filename, "2>/dev/null")
 
     // Check if we found the file
@@ -38,11 +39,11 @@ object AndroidPreload {
     found
   }
 
-  private def checkPreloadedScalaVersion (db: File, si: ScalaInstance, s: TaskStreams)(implicit emulator: Boolean) = {
+  private def checkPreloadedScalaVersion (db: File, si: ScalaInstance, s: TaskStreams)(implicit androidTarget: Symbol) = {
     import scala.xml._
 
     // Retrieve the contents of the `scala_library` permission file
-    val permissions = adbTask(db.absolutePath, emulator, s,
+    val permissions = adbTask(db.absolutePath, androidTarget, s,
       "shell", "cat /system/etc/permissions/scala-library-" + si.version + ".xml")
 
     // Parse the library file
@@ -75,19 +76,18 @@ object AndroidPreload {
    ****************************/
 
   private def doPreloadPermissions(
-    db: File, si: ScalaInstance, s: TaskStreams)(implicit emulator: Boolean): Unit = {
+    db: File, si: ScalaInstance, s: TaskStreams)(implicit androidTarget: Symbol): Unit = {
 
     // Inform the user
     s.log.info("Setting permissions for "
       + jarName(si.libraryJar, si.version))
 
     // Create the contents of the file
-    val xmlContent =
-      <permissions>
-        <library
-        name={{ "scala-library-" + si.version }}
-        file={{ deviceJarPath(si.libraryJar, si.version) }} />
-      </permissions>
+    val xmlContent = XML.loadString("""|<permissions>
+                                       |  <library
+                                       |  name={{ "scala-library-" + si.version }}
+                                       |  file={{ deviceJarPath(si.libraryJar, si.version) }} />
+                                       |</permissions>""")
 
     // Generate string from the XML
     val xmlString = scala.xml.Utility.toXML(
@@ -96,14 +96,14 @@ object AndroidPreload {
     ).toString.replace("\"", "\\\"")
 
     // Load the file on the device
-    adbTask (db.absolutePath, emulator, s,
+    adbTask (db.absolutePath, androidTarget, s,
       "shell", "echo", xmlString,
       ">", devicePermissionPath(si.version)
     )
   }
 
   private def doPreloadJar(
-    db: File, dx: File, target: File, si: ScalaInstance, s: TaskStreams)(implicit emulator: Boolean): Unit = {
+    db: File, dx: File, target: File, si: ScalaInstance, s: TaskStreams)(implicit androidTarget: Symbol): Unit = {
 
     // This is the temporary JAR path
     val name = jarName(si.libraryJar, si.version)
@@ -127,25 +127,25 @@ object AndroidPreload {
 
     // Load the file on the device
     s.log.info("Installing " + name)
-    adbTask (db.absolutePath, emulator, s,
+    adbTask (db.absolutePath, androidTarget, s,
       "push",
       tempJarPath.getAbsolutePath,
       deviceJarPath(si.libraryJar, si.version)
     )
   }
 
-  private def doReboot (db: File, s: TaskStreams)(implicit emulator: Boolean) = {
+  private def doReboot (db: File, s: TaskStreams)(implicit androidTarget: Symbol) = {
       s.log.info("Rebooting " + deviceDesignation)
-      if (emulator) adbTask(db.absolutePath, emulator, s, "emu", "kill")
-      else adbTask(db.absolutePath, emulator, s, "reboot")
+      if (androidTarget == 'emulator) adbTask(db.absolutePath, androidTarget, s, "emu", "kill")
+      else adbTask(db.absolutePath, androidTarget, s, "reboot")
       ()
   }
 
-  private def doRemountReadWrite (db: File, s: TaskStreams)(implicit emulator: Boolean) = {
+  private def doRemountReadWrite (db: File, s: TaskStreams)(implicit androidTarget: Symbol) = {
     s.log.info("Remounting /system as read-write")
-    adbTask(db.absolutePath, emulator, s, "root")
-    adbTask(db.absolutePath, emulator, s, "wait-for-device")
-    adbTask(db.absolutePath, emulator, s, "remount")
+    adbTask(db.absolutePath, androidTarget, s, "root")
+    adbTask(db.absolutePath, androidTarget, s, "wait-for-device")
+    adbTask(db.absolutePath, androidTarget, s, "remount")
   }
 
   /***************************
@@ -165,7 +165,7 @@ object AndroidPreload {
     val configContents = scala.io.Source.fromFile(configFile).mkString
 
     // Regexp to match the system dir
-    val sysre = "image.sysdir.1 *= *(.*)".r 
+    val sysre = "image.sysdir.1 *= *(.*)".r
 
     sysre findFirstIn configContents match {
       case Some(sysre(sys)) =>
@@ -191,18 +191,18 @@ object AndroidPreload {
         rwemuCmd.run
 
         // Remount system as read-write
-        adbTask(db.absolutePath, true, s, "wait-for-device")
-        adbTask(db.absolutePath, true, s, "root")
-        adbTask(db.absolutePath, true, s, "wait-for-device")
-        adbTask(db.absolutePath, true, s, "remount")
+        adbTask(db.absolutePath, 'emulator, s, "wait-for-device")
+        adbTask(db.absolutePath, 'emulator, s, "root")
+        adbTask(db.absolutePath, 'emulator, s, "wait-for-device")
+        adbTask(db.absolutePath, 'emulator, s, "remount")
 
       case None => throw new Exception("Unable to find the system image")
     }
   }
 
-  private def doKillEmu (db: File, s: TaskStreams)(implicit emulator: Boolean) = {
-      if (emulator)
-        adbTaskWithOutput(db.absolutePath, emulator, s, "emu", "kill")
+  private def doKillEmu (db: File, s: TaskStreams)(implicit androidTarget: Symbol) = {
+      if (androidTarget == 'emulator)
+        adbTaskWithOutput(db.absolutePath, androidTarget, s, "emu", "kill")
       ()
   }
 
@@ -211,17 +211,47 @@ object AndroidPreload {
    * Tasks related to preloading *
    *******************************/
 
+  private def preloadAnyTask =
+    (dbPath, dxPath, target, scalaInstance, streams) map {
+    (dbPath, dxPath, target, scalaInstance, streams) =>
+
+    // We're not using any device
+      implicit val androidTarget = 'any
+
+      // Wait for the device
+      adbTask(dbPath.absolutePath, androidTarget, streams, "wait-for-device")
+
+      // Check if the Scala library is already preloaded
+      checkPreloadedScalaVersion(dbPath, scalaInstance, streams) match {
+
+        // Don't do anything if the library is preloaded
+        case Some(_) => ()
+
+        // Preload the Scala library
+        case None =>
+          // Remount the device in read-write mode
+          doRemountReadWrite (dbPath, streams)
+
+          // Push files to the device
+          doPreloadJar         (dbPath, dxPath, target, scalaInstance, streams)
+          doPreloadPermissions (dbPath, scalaInstance, streams)
+
+          // Reboot / Kill emulator
+          doReboot (dbPath, streams); ()
+      }
+    }
+
   private def preloadDeviceTask =
     (dbPath, dxPath, target, scalaInstance, streams) map {
     (dbPath, dxPath, target, scalaInstance, streams) =>
 
       // We're not using the emulator
-      implicit val emulator = false
+      implicit val androidTarget = 'device
 
       // Wait for the device
-      adbTask(dbPath.absolutePath, emulator, streams, "wait-for-device")
+      adbTask(dbPath.absolutePath, androidTarget, streams, "wait-for-device")
 
-      // Check if the Scala library is already prelaoded
+      // Check if the Scala library is already preloaded
       checkPreloadedScalaVersion(dbPath, scalaInstance, streams) match {
 
         // Don't do anything if the library is preloaded
@@ -246,7 +276,7 @@ object AndroidPreload {
     (emulatorName, toolsPath, sdkPath, dbPath, dxPath, target, scalaInstance, streams) =>
 
       // We're using the emulator
-      implicit val emulator = true
+      implicit val androidTarget = 'emulator
 
       // Kill any running emulator
       doKillEmu (dbPath, streams)
@@ -262,22 +292,35 @@ object AndroidPreload {
       doKillEmu (dbPath, streams); ()
     }
 
-  private def commandTask(command: String)(implicit emulator: Boolean) =
+  private def commandTask(command: String)(implicit androidTarget: Symbol) =
     (dbPath, streams) map {
-      (d,s) => adbTask(d.absolutePath, emulator, s, command)
+      (d,s) => adbTask(d.absolutePath, androidTarget, s, command)
       ()
+    }
+
+  private def unloadAnyTask =
+    (dbPath, scalaInstance, streams) map {
+      (d,si,s) =>
+      implicit val androidTarget = 'any
+      adbTask(d.absolutePath, androidTarget, s, "root")
+      adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+      adbTask(d.absolutePath, androidTarget, s, "remount")
+      adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+      adbTask(d.absolutePath, androidTarget, s, "shell", "rm", deviceJarPath(si.libraryJar, si.version))
+      adbTask(d.absolutePath, androidTarget, s, "shell", "rm", devicePermissionPath(si.version))
+      s.log.info("Scala has been removed from the " + deviceDesignation)
     }
 
   private def unloadDeviceTask =
     (dbPath, scalaInstance, streams) map {
       (d,si,s) =>
-        implicit val emulator = false
-        adbTask(d.absolutePath, emulator, s, "root")
-        adbTask(d.absolutePath, emulator, s, "wait-for-device")
-        adbTask(d.absolutePath, emulator, s, "remount")
-        adbTask(d.absolutePath, emulator, s, "wait-for-device")
-        adbTask(d.absolutePath, emulator, s, "shell", "rm", deviceJarPath(si.libraryJar, si.version))
-        adbTask(d.absolutePath, emulator, s, "shell", "rm", devicePermissionPath(si.version))
+        implicit val androidTarget = 'device
+        adbTask(d.absolutePath, androidTarget, s, "root")
+        adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+        adbTask(d.absolutePath, androidTarget, s, "remount")
+        adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+        adbTask(d.absolutePath, androidTarget, s, "shell", "rm", deviceJarPath(si.libraryJar, si.version))
+        adbTask(d.absolutePath, androidTarget, s, "shell", "rm", devicePermissionPath(si.version))
         s.log.info("Scala has been removed from the " + deviceDesignation)
     }
 
@@ -286,7 +329,7 @@ object AndroidPreload {
     (emulatorName, toolsPath, sdkPath, d, dxPath, target, si, s) =>
 
         // We're using the emulator
-        implicit val emulator = true
+        implicit val androidTarget = 'emulator
 
         // Kill any running emulator
         doKillEmu (d, s)
@@ -295,13 +338,13 @@ object AndroidPreload {
         doStartEmuReadWrite (d, s, sdkPath, toolsPath, emulatorName, false)
 
         // Remove the scala libs
-        adbTask(d.absolutePath, emulator, s, "wait-for-device")
-        adbTask(d.absolutePath, emulator, s, "root")
-        adbTask(d.absolutePath, emulator, s, "wait-for-device")
-        adbTask(d.absolutePath, emulator, s, "remount")
-        adbTask(d.absolutePath, emulator, s, "wait-for-device")
-        adbTask(d.absolutePath, emulator, s, "shell", "rm", deviceJarPath(si.libraryJar, si.version))
-        adbTask(d.absolutePath, emulator, s, "shell", "rm", devicePermissionPath(si.version))
+        adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+        adbTask(d.absolutePath, androidTarget, s, "root")
+        adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+        adbTask(d.absolutePath, androidTarget, s, "remount")
+        adbTask(d.absolutePath, androidTarget, s, "wait-for-device")
+        adbTask(d.absolutePath, androidTarget, s, "shell", "rm", deviceJarPath(si.libraryJar, si.version))
+        adbTask(d.absolutePath, androidTarget, s, "shell", "rm", devicePermissionPath(si.version))
         doKillEmu (d, s)
 
         s.log.info("Scala has been removed from the " + deviceDesignation)
@@ -313,11 +356,13 @@ object AndroidPreload {
 
   lazy val settings: Seq[Setting[_]] = inConfig(Android) (Seq(
     // Preload Scala on the device/emulator
+    preloadAny <<= preloadAnyTask,
     preloadDevice <<= preloadDeviceTask,
     preloadEmulator <<= InputTask(
       (sdkPath)(AndroidProject.installedAvds(_)))(preloadEmulatorTask),
 
     // Uninstall previously preloaded Scala
+    unloadAny <<= unloadAnyTask,
     unloadDevice <<= unloadDeviceTask,
     unloadEmulator <<= InputTask(
       (sdkPath)(AndroidProject.installedAvds(_)))(unloadEmulatorTask)


### PR DESCRIPTION
Hi,

I was in need of being able to use the android-plugin with ADB over network, so I sat down at made this.

It's actually just a version of all the *-device and *-emulator commands which does not add the -d og -e parameter to the adb command, this makes the command work for any android device/platform, including devices connected over the network.

The actual commands to use look like this:

```
android:start-any
android:install-any
```

and so on...

If there is any issue with the pull-request please get back to me and I will take a look at it.
