### PR TITLE
Remove managedSourceDirectories modification

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -215,8 +215,6 @@ object AndroidBase {
     extractApkLibDependencies <<= apklibDependenciesTask,
     apklibPackage <<= apklibPackageTask,
 
-    managedSourceDirectories in Compile <<= (managedJavaPath, managedScalaPath) (Seq(_, _)),
-
     classesMinJarPath <<= (target, classesMinJarName) (_ / _),
     classesDexPath <<= (target, classesDexName) (_ / _),
     resourcesApkPath <<= (target, resourcesApkName) (_ / _),


### PR DESCRIPTION
This fixes adding correct source directories to Idea project files with
sbt-idea plugin version 1.4.0+. 

Plugin authors should not modify 'managedSourceDirectories' directly, 
but only provide 'sourceGenerator' which generates sources under a 
subdirectory of 'sourceManaged' setting of the scope as described here:
http://www.scala-sbt.org/0.12.3/docs/Howto/generatefiles.html
