### PR TITLE
Fixing aapt, idl and dx paths from new build-tools

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -193,6 +193,8 @@ object AndroidBase {
   lazy val settings: Seq[Setting[_]] = inConfig(Android) (Seq (
     platformPath <<= (sdkPath, platformName) (_ / "platforms" / _),
 
+    buildToolsVersion <<= (platformName) (_.split('-').last + ".0.0"),
+
     packageApkName <<= (artifact, versionName) map ((a, v) => String.format("%s-%s.apk", a.name, v)),
     packageApkPath <<= (target, packageApkName) map (_ / _),
     packageApkLibName <<= (artifact, versionName) map ((a, v) => String.format("%s-%s.apklib", a.name, v)),

--- a/src/main/scala/AndroidKeys.scala
+++ b/src/main/scala/AndroidKeys.scala
@@ -46,15 +46,17 @@ object AndroidKeys {
 
   /** Path Settings */
   val sdkPath = SettingKey[File]("sdk-path")
+  val platformToolsPath = SettingKey[File]("platform-tools-path")
+  val buildToolsPath = SettingKey[File]("build-tools-path")
   val toolsPath = SettingKey[File]("tools-path")
   val dbPath = SettingKey[File]("db-path")
-  val platformPath = SettingKey[File]("platform-path")
   val aaptPath = SettingKey[File]("apt-path")
   val idlPath = SettingKey[File]("idl-path")
   val dxPath = SettingKey[File]("dx-path")
 
   /** Base Settings */
-  val platformToolsPath = SettingKey[File]("platform-tools-path")
+  val platformPath = SettingKey[File]("platform-path")
+  val buildToolsVersion = SettingKey[String]("build-tools-version")
   val manifestPackage = TaskKey[String]("manifest-package")
   val manifestPackageName = TaskKey[String]("manifest-package-name")
   val minSdkVersion = TaskKey[Option[Int]]("min-sdk-version")

--- a/src/main/scala/AndroidPath.scala
+++ b/src/main/scala/AndroidPath.scala
@@ -15,9 +15,13 @@ object AndroidPath {
     toolsPath <<= (sdkPath) (_ / "tools"),
     dbPath <<= (platformToolsPath, adbName) (_ / _),
     platformToolsPath <<= (sdkPath) (_ / "platform-tools"),
-    aaptPath <<= (platformToolsPath, aaptName) (_ / _),
-    idlPath <<= (platformToolsPath, aidlName) (_ / _),
-    dxPath <<= (platformToolsPath, osDxName) (_ / _),
+    buildToolsPath <<= (sdkPath, platformToolsPath, buildToolsVersion) { (sdkPath, platformToolsPath, buildToolsVersion) =>
+      val btp = sdkPath / "build-tools"
+      if (btp.exists()) (btp / buildToolsVersion) else platformToolsPath
+    },
+    aaptPath <<= (buildToolsPath, aaptName) (_ / _),
+    idlPath <<= (buildToolsPath, aidlName) (_ / _),
+    dxPath <<= (buildToolsPath, osDxName) (_ / _),
 
     sdkPath <<= (envs, baseDirectory) { (es, dir) =>
       determineAndroidSdkPath(es).getOrElse {


### PR DESCRIPTION
The 'Android SDK Build-tools are not installed in the platform-tools anymore but in build-tools/[version].
I added a new key buildToolsPath and the user defined key buildToolsVersion. Using these the aapt, idl and dx binaries can be found again.
