### PR TITLE
No Apklib extraction for the "provided" scope

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -78,7 +78,9 @@ object AndroidBase {
     (update in Compile, sourceManaged, managedJavaPath, resourceManaged, streams) map {
     (updateReport, srcManaged, javaManaged, resManaged, s) => {
 
-      val apklibs = updateReport.matching(artifactFilter(`type` = "apklib"))
+      val allApklibs = updateReport.matching(artifactFilter(`type` = "apklib"))
+      val providedDependencies = updateReport.matching(configurationFilter(name = "provided"))
+      val apklibs = allApklibs --- providedDependencies get
 
       apklibs map  { apklib =>
         s.log.info("extracting apklib " + apklib.name)


### PR DESCRIPTION
See [this discussion](https://groups.google.com/forum/?fromgroups=#!topic/scala-on-android/OuGYJtvQdZo) on the mailing list.

ApkLib dependencies in the "provided" scope should already be present (and compiled) in one of the dependencies, and thus don't need to be extracted in the subprojects.
