### PR TITLE
Force the use of Java 6 class files

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -322,6 +322,20 @@ object AndroidBase {
   val providedInternalDependencies = TaskKey[Seq[File]]("provided-internal-dependencies")
 
   lazy val globalSettings: Seq[Setting[_]] = Seq(
+
+    // At the moment, we NEED to use Java 6 class files
+    javacOptions ++= Seq(
+      "-encoding", "utf8",
+      "-target", "1.6",
+      "-source", "1.6"
+    ),
+
+    // Same thing for Scalac
+    scalacOptions ++= Seq(
+      "-encoding", "utf8",
+      "-target:jvm-1.6"
+    ),
+
     // By default, use the first device we find as the ADB target
     adbTarget in Global := AndroidDefaultTargets.Auto,
 


### PR DESCRIPTION
Using the plugin with an active Java 7 installation caused it to generate Java 7 class files by default. Bugs caused by this ranged from not being able to build the app (`dex` bailed out when seeing the invalid file) to simply missing parts of the app (the missing `R.class` was reported lots of times). This commit fixes that by setting the correct `scalacOptions` and `javacOptions` by default in the plugin.
