### PR TITLE
Add -sigalg and -digestalg options for jarsigner to be able to sign an apk in jdk 7

### DIFF
--- a/src/main/scala/AndroidRelease.scala
+++ b/src/main/scala/AndroidRelease.scala
@@ -25,6 +25,8 @@ object AndroidRelease {
       val jarsigner = Seq(
         "jarsigner",
         "-verbose",
+        "-sigalg", "SHA1withRSA",
+        "-digestalg", "SHA1",
         "-keystore", ksPath.absolutePath,
         "-storepass", PasswordManager.get(
               "keystore", ka, cache).getOrElse(sys.error("could not get password")),


### PR DESCRIPTION
The default digest algorithm of jarsigner for Java 1.7 is SHA256withRSA which isn't supported in Android, while for Java 1.6 it's MD5withRSA
So "-sigalg SHA1withRSA -digestalg SHA1" options are needed to sign correctly in jdk 7.

See this discussion for more details.

http://stackoverflow.com/questions/8739564/what-is-the-difference-between-the-java-1-6-and-1-7-jarsigner
