### PR TITLE
Add another typed resources task

### DIFF
--- a/src/main/scala/AndroidBase.scala
+++ b/src/main/scala/AndroidBase.scala
@@ -386,6 +386,9 @@ object AndroidBase {
     // Use typed resources by default
     useTypedResources := true,
 
+    // Use typed resources 2 by default
+    useTypedResources2 := true,
+
     // Gradle uses libs/ as the unmanaged JAR directory!
     unmanagedBase <<= (baseDirectory) (_ / "libs"),
 

--- a/src/main/scala/AndroidJavaLayout.scala
+++ b/src/main/scala/AndroidJavaLayout.scala
@@ -10,6 +10,7 @@ object AndroidJavaLayout {
     autoScalaLibrary in GlobalScope := false,
     useProguard in Compile := false,
     useTypedResources in Compile := false,
+    useTypedResources2 in Compile := false,
     manifestPath in Compile <<= (baseDirectory, manifestName) map((s,m) => Seq(s / m)) map (x=>x),
     mainResPath in Compile <<= (baseDirectory, resDirectoryName) (_ / _) map (x=>x),
     mainAssetsPath in Compile <<= (baseDirectory, assetsDirectoryName) (_ / _),

--- a/src/main/scala/AndroidPlugin.scala
+++ b/src/main/scala/AndroidPlugin.scala
@@ -76,6 +76,7 @@ object AndroidPlugin extends Plugin {
   val usePreloaded = SettingKey[Boolean]("use-preloaded", "Use preloaded libraries for development")
   val useDebug = SettingKey[Boolean]("use-debug", "Use debug settings when building an APK")
   val useTypedResources = SettingKey[Boolean]("use-typed-resources", "Use typed resources")
+  val useTypedResources2 = SettingKey[Boolean]("use-typed-resources2", "Use typed resources 2")
 
   /** ApkLib dependencies */
   case class LibraryProject(pkgName: String, manifest: File, sources: Set[File], resDir: Option[File], assetsDir: Option[File])
@@ -194,6 +195,9 @@ object AndroidPlugin extends Plugin {
   val typedResource = TaskKey[File]("typed-resource",
     """Typed resource file to be generated, also includes
        interfaces to access these resources.""")
+  val typedResource2 = TaskKey[File]("typed-resource2",
+    """Typed resource file to be generated, also includes
+       interfaces to access these resources.""")
   val layoutResources = TaskKey[Seq[File]]("layout-resources",
       """All files that are in res/layout. They will
 		 be accessable through TR.layouts._""")
@@ -215,6 +219,9 @@ object AndroidPlugin extends Plugin {
     "Generate Java classes from .aidl files.")
   val generateTypedResources = TaskKey[Seq[File]]("generate-typed-resources",
     """Produce a file TR.scala that contains typed
+       references to layout resources.""")
+  val generateTypedResources2 = TaskKey[Seq[File]]("generate-typed-resources2",
+    """Produce a file typed_resource.scala that contains typed
        references to layout resources.""")
   val generateManifest = TaskKey[Seq[File]]("generate-manifest",
     """Generates a customized AndroidManifest.xml with

--- a/src/main/scala/AndroidProjects.scala
+++ b/src/main/scala/AndroidProjects.scala
@@ -24,6 +24,7 @@ object AndroidProjects {
         AndroidTest.settings ++
         AndroidNdk.settings ++
         TypedResources.settings ++
+        TypedResources2.settings ++
         Seq(
           // Test projects are Debug projects by default
           useDebug := true,
@@ -37,7 +38,8 @@ object AndroidProjects {
           // It's highly unlikely that you'll need typed resources in test
           // projects, but you can enable it afterwards anyway, if you really
           // need it.
-          useTypedResources := false
+          useTypedResources := false,
+          useTypedResources2 := false
         )
       )
 
@@ -91,7 +93,8 @@ object AndroidProjects {
       AndroidDdm.settings ++
       AndroidLaunch.settings ++
       AndroidNdk.settings ++
-      TypedResources.settings
+      TypedResources.settings ++
+      TypedResources2.settings
     }
 
     // Development settings

--- a/src/main/scala/TypedResources2.scala
+++ b/src/main/scala/TypedResources2.scala
@@ -1,0 +1,285 @@
+package sbtandroid
+
+import sbt.{stringToProcess => _, _}
+import classpath._
+import scala.xml._
+
+import Keys._
+import AndroidPlugin._
+
+// FIXME more appropriate name
+object TypedResources2 {
+  /** Views with android:id. */
+  private case class NamedView(id: String,
+                               className: String,
+                               subViews: Iterable[NamedView]) {
+    def flatten: Iterable[NamedView] = {
+      Iterable(this) ++ subViews.flatMap(_.flatten)
+    }
+  }
+
+  /** Returns tree nodes represents views with android:id */
+  private def buildTree(jarPath: File)(element: Elem): Iterable[NamedView] = {
+    val androidJarLoader = ClasspathUtilities.toLoader(jarPath)
+
+    /** Returns a class object if exits. */
+    def tryLoading(className: String): Option[Class[_]] = {
+      try {
+        Some(androidJarLoader.loadClass(className))
+      } catch {
+        case e: Exception => None
+        case e: LinkageError => None
+      }
+    }
+
+    def attributeText(element: Elem,
+                      namespace: String,
+                      localName: String) = {
+      element
+        .attribute(namespace, localName)
+        .map(_.map(_.text).mkString)
+    }
+
+    val androidNamespace = "http://schemas.android.com/apk/res/android"
+
+    /** regexp extracting id */
+    val Id = """@\+id/(.*)""".r
+
+    val idOption =
+      attributeText(element, androidNamespace, "id")
+        .collect({ case Id(id) => id })
+
+    // node.label is either fully qualified class name or
+    // unqualified class name.
+    val classNameOption = if (element.label.contains('.')) {
+      Some(element.label)
+    } else {
+      List("android.widget.", "android.view.", "android.webkit.")
+        .map(_ + element.label)
+        .flatMap(tryLoading _)
+        .headOption
+        .map(_.getName)
+        .map("_root_." + _)
+    }
+
+    val pairOption = for {
+      id <- idOption
+      className <- classNameOption
+    } yield {
+      (id, className)
+    }
+
+    val subViews =
+      element.child.collect({ case e: Elem => e }).flatMap(buildTree(jarPath) _)
+
+    pairOption match {
+      case Some((id, className)) =>
+        Seq(NamedView(id, className, subViews))
+      case None =>
+        subViews
+    }
+  }
+
+  /** Merges layout definitions having the same name. */
+  private def mergeLayouts(streams: std.TaskStreams[Project.ScopedKey[_]])
+                          (layouts: Iterable[(String, Iterable[NamedView])]) = {
+    def mergeViews(views: Iterable[NamedView]): Iterable[NamedView] = {
+      views.groupBy(_.id).values.map(doMergeViews _)
+    }
+
+    def doMergeViews(views: Iterable[NamedView]): NamedView = {
+      val id = views.head.id
+      val className = views.head.className
+
+      for (view <- views) {
+        if (view.className != className) {
+          streams.log.warn("Resource id '%s' mapped to %s and %s"
+                             .format(id, className, view.className))
+        }
+      }
+
+      NamedView(id, className, mergeViews(views.flatMap(_.subViews)))
+    }
+
+    def toMultimap[A, B](tuples: Iterable[(A, B)]) = {
+      tuples.groupBy(_._1).mapValues(_.map(_._2))
+    }
+
+    toMultimap(layouts).mapValues(_.flatten).mapValues(mergeViews _)
+  }
+
+  /** Reserved words of Scala language */
+  // from Scala Language Specification Version 2.9 Section 1.1
+  private val reserved =
+    Set("abstract", "case", "do", "else", "finally", "for", "import",
+        "lazy", "object", "override", "return", "sealed", "trait", "try",
+        "var", "while", "catch", "class", "extends", "false", "forSome",
+        "if", "match", "new", "package", "private", "super", "this",
+        "true", "type", "with", "yield", "def", "final", "implicit",
+        "null", "protected", "throw", "val")
+
+  /** Quotes a qualified/unqualified identifier if it is reserved */
+  private def quoteReserved(id: String) = {
+    id.split("\\.").map(id =>
+      if (reserved.contains(id)) {
+        "`" + id + "`"
+      } else {
+        id
+      }
+    ).mkString(".")
+  }
+
+  private def toCamelCase(name: String) = {
+    "(.)_".r.replaceAllIn(name, _.group(1).toUpperCase)
+  }
+
+  private def toUpperCamelCase(name: String) = {
+    toCamelCase(name).capitalize
+  }
+
+  // FIXME Name clashes occur if duplicated IDs exist.
+  private def formatLayout(manifestPackage: String)
+                          (layout: (String, Iterable[NamedView])) = {
+    val (layoutName, views) = layout
+
+    // Since Activity, Dialog, and View does not have a common interface,
+    // we generate four types: common trait, base trait for Activity,
+    // base trait for Dialog, and view wrapper suitable for use with such as
+    // SimplerAdapter.ViewBinder.
+    """|trait %1$s {
+       |  // to avoid name shadowing in pathological cases.
+       |  `this` =>
+       |
+       |  def findViewById(id: _root_.scala.Int): _root_.android.view.View
+       |
+       |  object views {
+       |    %2$s
+       |  }
+       |}
+       |
+       |object %1$s {
+       |  trait Activity extends _root_.android.app.Activity with %4$s.typed_resource.layout.%1$s {
+       |    protected override def onCreate(savedInstanceState: _root_.android.os.Bundle) {
+       |      super.onCreate(savedInstanceState)
+       |
+       |      setContentView(%4$s.R.layout.%3$s)
+       |    }
+       |  }
+       |
+       |  trait Dialog extends _root_.android.app.Dialog with %4$s.typed_resource.layout.%1$s {
+       |    protected override def onCreate(savedInstanceState: _root_.android.os.Bundle) {
+       |      super.onCreate(savedInstanceState)
+       |
+       |      setContentView(%4$s.R.layout.%3$s)
+       |    }
+       |  }
+       |
+       |  class ViewWrapper(view: _root_.android.view.View) extends %4$s.typed_resource.ViewWrapper(view) with %4$s.typed_resource.layout.%1$s {
+       |    override def findViewById(id: _root_.scala.Int) = {
+       |      view.findViewById(id)
+       |    }
+       |  }
+       |
+       |  def apply(view: _root_.android.view.View) = new ViewWrapper(view)
+       |}
+       |""".stripMargin.format(toUpperCamelCase(layoutName),
+                               views
+                                 .flatMap(_.flatten)
+                                 .map(formatView(manifestPackage)(layoutName, _))
+                                 .mkString("\n")
+                                 .lines
+                                 .mkString("\n    "),
+                               quoteReserved(layoutName),
+                               "_root_." + manifestPackage)
+  }
+
+  private def formatView(manifestPackage: String)
+                        (layoutName: String, view: NamedView) = {
+    if (view.subViews.isEmpty) {
+      "lazy val %1$s = `this`.findViewById(%3$s.R.id.%1$s).asInstanceOf[%2$s]"
+        .format(quoteReserved(view.id),
+                quoteReserved(view.className),
+                "_root_." + manifestPackage)
+    } else {
+      """|object %1$s extends %4$s.typed_resource.ViewWrapper[%2$s](`this`.findViewById(%4$s.R.id.%1$s).asInstanceOf[%2$s]) {
+         |  object views {
+         |    %3$s
+         |  }
+         |}
+         |""".stripMargin.format(quoteReserved(view.id),
+                                 quoteReserved(view.className),
+                                 view
+                                   .subViews
+                                   .flatMap(_.flatten)
+                                   .map(formatSubView(layoutName, _))
+                                   .mkString("\n")
+                                   .lines
+                                   .mkString("\n    "),
+                                 "_root_." + manifestPackage
+      )
+    }
+  }
+
+  private def formatSubView(layoutName: String, view: NamedView) = {
+    "def %1$s = `this`.views.%1$s".format(quoteReserved(view.id))
+  }
+
+  private def generateTypedResources2Task =
+    (useTypedResources2, typedResource2, layoutResources, libraryJarPath, manifestPackage, streams) map {
+    (useTypedResources2, typedResource2, layoutResources, libraryJarPath, manifestPackage, s) =>
+      if (useTypedResources2) {
+        // e.g. main_activity.xml -> main_activity
+        def baseName(path: File) = {
+          val name = path.getName
+
+          name.substring(0, name.lastIndexOf("."))
+        }
+
+        val layouts = mergeLayouts(s)(
+          layoutResources.get.map(path =>
+            (baseName(path), buildTree(libraryJarPath)(XML.loadFile(path)))
+          )
+        )
+
+        IO.write(typedResource2,
+                 """|package %s
+                    |
+                    |package typed_resource {
+                    |  case class ViewWrapper[A <: _root_.android.view.View](view: A)
+                    |  object ViewWrapper {
+                    |    implicit def unwrap[A <: _root_.android.view.View](v: ViewWrapper[A]): A = v.view
+                    |  }
+                    |
+                    |  package layout {
+                    |    %s
+                    |  }
+                    |}
+                    |"""
+                   .stripMargin.format(manifestPackage,
+                                       layouts
+                                         .map(formatLayout(manifestPackage) _)
+                                         .mkString("\n")
+                                         .lines
+                                         .mkString("\n    ")
+                 )
+        )
+        s.log.info("Wrote %s".format(typedResource2))
+        Seq(typedResource2)
+      } else {
+        Seq.empty
+      }
+    }
+
+  lazy val settings: Seq[Setting[_]] = (Seq (
+    typedResource2 <<= (manifestPackage, managedScalaPath) map {
+      _.split('.').foldLeft(_) ((p, s) => p / s) / "typed_resource.scala"
+    },
+    layoutResources <<= (mainResPath) map { x => (x * "layout*" * "*.xml" get) },
+
+    generateTypedResources2 <<= generateTypedResources2Task,
+
+    sourceGenerators <+= generateTypedResources2,
+
+    watchSources <++= (layoutResources) map (ls => ls)
+  ))
+}


### PR DESCRIPTION
I wrote another typed resources task. This utilize lazy val for more natural interface. For example, suppose we have the following layout:
login.xml:

``` xml
<LinearLayout>
  <EditText android:id="username"/>
  <EditText android:id="password" android:inputType="textPassword"/>
  <Button android:id="loginButton" android:text="Login"/>
</LinearLayout>
```

An activity using conventional typed resources may be like this:

``` scala
class LoginActivity extends Activity {
  var usernameField: EditText = _
  var passwordField: EditText = _

  protected override def onCreate(savedInstanceState: Bundle) {
    super.onCreate(savedInstanceState)

    setContentView(R.layout.login)

    usernameField = findView(TR.layout.username)
    passwordField = findView(TR.layout.password)

    findView(TR.layout.loginButton).setOnClickListener(
      new View.OnClickListener {
        override def onClick(view: View) {
          doLogin()
        }
      }
    )
  }

  def doLogin() {
    val username = usernameField.getText
    val password = passwordField.getText

    ...
  }
}
```

With new typed resources, we can write it more concisely:

``` scala
class LoginActivity extends typed_resource.layout.Login.Activity {
  protected override def onCreate(savedInstanceState: Bundle) {
    super.onCreate(savedInstanceState)

    views.loginButton.setOnClickListener(
      new View.OnClickListener {
        override def onClick(view: View) {
          doLogin()
        }
      }
    )
  }

  def doLogin() {
    val username = views.username.getText
    val password = views.password.getText

    ...
  }
}
```

Note that we do not have to call `setContentView`.

Views such as `views.loginButton` are defined with `lazy val`.

Since `typed_resource.layout.Login.Activity` is a trait rather than a class, we can use custom base activities:

``` scala
class LoginActivity extends MyBaseActivity with typed_resource.layout.Login.Activity {
  ...
}
```

We can also define dialogs in a similar way:

``` scala
class LoginDialog extends with typed_resource.layout.Login.Dialog {
  ...
}
```

Moreover, we also have wrappers suitable for use with `LayoutInflater` or `SimplerAdapter.ViewBinder`:

``` scala
val layout = typed_resource.layout.Login(layoutInflater.inflate(R.layout.login, container))

layout.views.username.setText(username)
...
```

I will enhance this task to generate other value resources (e.g. strings, ints, colors).

I named it `TypedResources2` provisionally, but more appropriate name is wanted. Are there any better names?
