### PR TITLE
Attempt of making aapt --rename-manifest-package configurable (Issue #19...

### DIFF
--- a/src/main/scala/AndroidPlugin.scala
+++ b/src/main/scala/AndroidPlugin.scala
@@ -115,6 +115,7 @@ object AndroidPlugin extends Plugin {
   /** APK Generation **/
   val apk = TaskKey[File]("apk", "Package and sign with a debug key.")
   val aaptPackage = TaskKey[File]("aapt-package", "Package resources and assets.")
+  val aaptRenameManifestPackage = SettingKey[Option[String]]("appt-rename-manifest-package", "Can be set if the package in generated AndroidManifest should be a different one.")
   val cleanApk = TaskKey[Unit]("clean-apk", "Remove apk package")
 
   /** Install Scala on device/emulator **/


### PR DESCRIPTION
I tried to implement the rename-manifest-package option for aapt (Issue #191).
It looks fine to me, the option is really appended to the aapt call (I verified it). However, the generated Android app does not have the changed package name.
I don't know what the problem could be. Perhaps someone else has a clue?
