### PR TITLE
Add debug task

### DIFF
--- a/src/main/scala/AndroidLaunch.scala
+++ b/src/main/scala/AndroidLaunch.scala
@@ -16,10 +16,20 @@ object AndroidLaunch {
     }
   )
 
+  val debugTask = (
+    (adbTarget, dbPath, streams, manifestSchema, manifestPackage, manifestPath) map {
+    (adbTarget, dbPath, streams, manifestSchema, manifestPackage, manifestPath) =>
+      adbTarget.debugApp(dbPath, streams, manifestSchema, manifestPackage, manifestPath)
+      ()
+    }
+  )
+
   lazy val settings: Seq[Setting[_]] =
     AndroidInstall.settings ++
     (Seq (
       start <<= startTask,
-      start <<= start dependsOn install
+      start <<= start dependsOn install,
+      debug <<= debugTask,
+      debug <<= debug dependsOn install
     ))
 }

--- a/src/main/scala/AndroidPlugin.scala
+++ b/src/main/scala/AndroidPlugin.scala
@@ -128,6 +128,7 @@ object AndroidPlugin extends Plugin {
 
   /** Launch Tasks */
   val start = TaskKey[Unit]("start", "Start package on device after installation")
+  val debug = TaskKey[Unit]("debug", "Start package on device after installation, and wait for a debugger to attach")
 
   /** Modules that are preloaded on the device **/
   val preinstalledModules = SettingKey[Seq[ModuleID]]("preinstalled-modules")

--- a/src/main/scala/AndroidTarget.scala
+++ b/src/main/scala/AndroidTarget.scala
@@ -85,6 +85,22 @@ trait AndroidTarget {
     )
   }
 
+  def debugApp(
+    adbPath: File,
+    s: TaskStreams,
+    manifestSchema: String,
+    manifestPackage: String,
+    manifestPath: Seq[java.io.File]) = {
+
+    // Run the command
+    run(adbPath, s,
+      "shell", "am", "set-debug-app",
+      "-w",
+      manifestPackage
+    )
+    startApp(adbPath, s, manifestSchema, manifestPackage, manifestPath)
+  }
+
   /**
    * Runs instrumentation tests on an app
    */


### PR DESCRIPTION
Similar to start task, but waits for a debugger to be attached.
Allows testing onCreate methods, that otherwise run as soon as you start, and don't allow one to attach a debugger.
